### PR TITLE
Update bipartite network viz plugin api to match new correlation compute api

### DIFF
--- a/schema/library.raml
+++ b/schema/library.raml
@@ -1328,11 +1328,27 @@ types:
     properties:
       computeConfig: CorrelationConfig
       config: CorrelationNetworkSpec
+  CorrelationInputDataCollection:
+    type: object
+    properties:
+      dataType:
+        type: string
+        enum:
+          - collection
+      collectionSpec: CollectionSpec
+  CorrelationInputDataMetadata:
+    type: object
+    properties:
+      dataType:
+        type: string
+        enum:
+          - metadata
   CorrelationAssayAssayConfig:
     type: BaseCorrelationComputeConfig
     properties:
-      collectionVariable: CollectionSpec
-      collectionVariable2: CollectionSpec
+      correlationMethod: CorrelationMethod
+      data1: CorrelationInputDataCollection
+      data2: CorrelationInputDataCollection
   CorrelationAssayAssayBipartitenetworkPostRequest:
     type: DataPluginRequestBase
     properties:
@@ -1341,7 +1357,9 @@ types:
   CorrelationAssayMetadataConfig:
     type: BaseCorrelationComputeConfig
     properties:
-      collectionVariable: CollectionSpec
+      correlationMethod: CorrelationMethod
+      data1: CorrelationInputDataCollection
+      data2: CorrelationInputDataMetadata
   CorrelationAssayMetadataBipartitenetworkPostRequest:
     type: DataPluginRequestBase
     properties:

--- a/schema/url/data/correlation/plugin-correlation-bipartitenetwork.raml
+++ b/schema/url/data/correlation/plugin-correlation-bipartitenetwork.raml
@@ -32,11 +32,26 @@ types:
   # these are flavors of CorrelationBipartitenetworkPostRequest
   # they are intended to help the /apps endpoint users distinguish
   # different variations of this compute + viz combo
+
+  CorrelationInputDataCollection:
+    properties:
+      dataType: 
+        type: string
+        enum: ['collection']
+      collectionSpec: CollectionSpec
+
+  CorrelationInputDataMetadata:
+    properties:
+      dataType: 
+        type: string
+        enum: ['metadata']
+
   CorrelationAssayAssayConfig:
     type: BaseCorrelationComputeConfig
     properties:
-      collectionVariable: CollectionSpec
-      collectionVariable2: CollectionSpec
+      correlationMethod: CorrelationMethod
+      data1: CorrelationInputDataCollection
+      data2: CorrelationInputDataCollection
 
   CorrelationAssayAssayBipartitenetworkPostRequest:
     type: DataPluginRequestBase
@@ -44,10 +59,14 @@ types:
       computeConfig: CorrelationAssayAssayConfig
       config: CorrelationNetworkSpec
 
+# The Correlation Assay Metadata viz requires a collection as data1
+# and metadata as data2. Note this is different than the standard CorrelationConfig
   CorrelationAssayMetadataConfig:
     type: BaseCorrelationComputeConfig
     properties:
-      collectionVariable: CollectionSpec
+      correlationMethod: CorrelationMethod
+      data1: CorrelationInputDataCollection
+      data2: CorrelationInputDataMetadata
 
   CorrelationAssayMetadataBipartitenetworkPostRequest:
     type: DataPluginRequestBase

--- a/src/main/java/org/veupathdb/service/eda/data/service/AppsService.java
+++ b/src/main/java/org/veupathdb/service/eda/data/service/AppsService.java
@@ -19,6 +19,7 @@ import org.veupathdb.service.eda.Resources;
 import org.veupathdb.service.eda.data.metadata.AppsMetadata;
 import org.veupathdb.service.eda.data.core.AbstractPlugin;
 import org.veupathdb.service.eda.data.plugin.correlation.CorrelationAssayAssayBipartitenetworkPlugin;
+import org.veupathdb.service.eda.data.plugin.correlation.CorrelationAssayMetadataBipartitenetworkPlugin;
 import org.veupathdb.service.eda.data.plugin.differentialabundance.DifferentialAbundanceVolcanoplotPlugin;
 import org.veupathdb.service.eda.data.plugin.betadiv.BetaDivScatterplotPlugin;
 import org.veupathdb.service.eda.data.plugin.correlation.CorrelationBipartitenetworkPlugin;
@@ -166,6 +167,7 @@ public class AppsService implements Apps {
       throw new BadRequestException(e.getMessage());
     }
     catch (EmptyResultException e) {
+      LOG.info("Found empty body.", e);
       throw new WebApplicationException(e.getMessage(), 204);
     }
     catch (WebApplicationException e) {
@@ -365,11 +367,13 @@ public class AppsService implements Apps {
         new CorrelationNetworkPostResponseStream(processRequest(new SelfCorrelationUnipartitenetworkPlugin(), entity))));
   }
 
+  @DisableJackson
   @Override
   public PostAppsCorrelationassaymetadataVisualizationsBipartitenetworkResponse postAppsCorrelationassaymetadataVisualizationsBipartitenetwork(CorrelationAssayMetadataBipartitenetworkPostRequest entity) {
-    return null;
+    return wrapPlugin(() -> PostAppsCorrelationassaymetadataVisualizationsBipartitenetworkResponse.respond200WithApplicationJson(
+        new CorrelationBipartiteNetworkPostResponseStream(processRequest(new CorrelationAssayMetadataBipartitenetworkPlugin(), entity))));
   }
-
+  
   @DisableJackson
   @Override
   public PostAppsAbundanceVisualizationsBoxplotResponse postAppsAbundanceVisualizationsBoxplot(AbundanceBoxplotPostRequest entity) {


### PR DESCRIPTION
Noticed that no data was being returned for the bipartite network post requests. Realized the plugin wasn't even running!

Confirmed this fixes the issue for

- [x] mbio assay v assay
- [ ] mbio assay v metadata
- [x] genomics any v any


Why does the assay v metadata not work? Is it the same issue or something different?

Update 04/17 - problem fixed by @dmgaldi !! Woot!!