### PR TITLE
update genomics correlation name to use wgcna

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/data/metadata/AppsMetadata.java
+++ b/src/main/java/org/veupathdb/service/eda/data/metadata/AppsMetadata.java
@@ -139,7 +139,7 @@ public class AppsMetadata {
           "Uncover connections between taxonomic abundance and functional data such as genes or pathways.",
           List.of(MICROBIOME_PROJECT),
           viz("bipartitenetwork", new CorrelationBipartitenetworkPlugin())),
-      app("correlation", "Correlation (Eigengene v. Eigengene, Metadata)", "correlation",
+      app("correlation", "WGCNA Correlation (Eigengene v. Eigengene, Metadata)", "correlation",
           "Discover relationships between eigenengenes and metadata or other eigengenes.",
           NON_VB_GENOMICS_PROJECTS,
           viz("bipartitenetwork", new CorrelationBipartitenetworkPlugin())),


### PR DESCRIPTION
Resolves #12 

Genomics asked to add "WGCNA" into the name of their correlation app.