### PR TITLE
Fix empty subsetting response causing 500

### DIFF
--- a/api-test/src/test/kotlin/ApiTest.kt
+++ b/api-test/src/test/kotlin/ApiTest.kt
@@ -72,32 +72,33 @@ class ApiTest {
         logger().info("Received count values: $overlayValues")
     }
 
-//    @Test
-//    fun variableMetaTest() {
-//        val studyIds = given()
-//            .contentType(ContentType.JSON)
-//            .header(AuthTokenKey, AuthToken)
-//            .`when`()
-//            .get("studies")
-//            .then()
-//            .statusCode(200)
-//            .contentType(ContentType.JSON)
-//            .extract()
-//            .path<List<String>>("studies.id")
-//
-//        logger().info("Found studies: $studyIds")
-//
-//        studyIds.stream()
-//            .forEach {
-//                given()
-//                    .contentType(ContentType.JSON)
-//                    .header(AuthTokenKey, AuthToken)
-//                    .`when`()
-//                    .get("studies/${it}")
-//                    .then()
-//                    .statusCode(200)
-//            }
-//    }
+    // TODO: RE-enable when studies with empty metadata are removed or fully loaded.
+    //    @Test
+    fun variableMetaTest() {
+        val studyIds = given()
+            .contentType(ContentType.JSON)
+            .header(AuthTokenKey, AuthToken)
+            .`when`()
+            .get("studies")
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .extract()
+            .path<List<String>>("studies.id")
+
+        logger().info("Found studies: $studyIds")
+
+        studyIds.stream()
+            .forEach {
+                given()
+                    .contentType(ContentType.JSON)
+                    .header(AuthTokenKey, AuthToken)
+                    .`when`()
+                    .get("studies/${it}")
+                    .then()
+                    .statusCode(200)
+            }
+    }
 
     /**
      * Provide bubble test cases from YAML file.

--- a/api-test/src/test/kotlin/DonutMarkerTestCase.kt
+++ b/api-test/src/test/kotlin/DonutMarkerTestCase.kt
@@ -1,1 +1,3 @@
-data class DonutMarkerTestCase(val expectedMarkerCount: Int, val body: String)
+data class DonutMarkerTestCase(val expectedMarkerCount: Int,
+                               val body: String,
+                               val expectedResponseCode: Int?)

--- a/api-test/src/test/resources/testdata/test-cases.yaml
+++ b/api-test/src/test/resources/testdata/test-cases.yaml
@@ -1,4 +1,53 @@
 donuts:
+- expectedResponseCode: 204
+  body: |
+    {
+    "studyId": "VBP_MEGA",
+    "filters": [
+        {
+            "type": "dateRange",
+            "entityId": "OBI_0000659",
+            "variableId": "EUPATH_0043256",
+            "min": "1945-10-11T00:00:00Z",
+            "max": "1951-10-17T00:00:00Z"
+        }
+    ],
+    "config": {
+        "geoAggregateVariable": {
+            "entityId": "GAZ_00000448",
+            "variableId": "EUPATH_0043203"
+        },
+        "latitudeVariable": {
+            "entityId": "GAZ_00000448",
+            "variableId": "OBI_0001620"
+        },
+        "longitudeVariable": {
+            "entityId": "GAZ_00000448",
+            "variableId": "OBI_0001621"
+        },
+        "overlayConfig": {
+            "overlayType": "categorical",
+            "overlayVariable": {
+                "variableId": "OBI_0001909",
+                "entityId": "EUPATH_0000609"
+            },
+            "overlayValues": []
+        },
+        "outputEntityId": "EUPATH_0000609",
+        "valueSpec": "count",
+        "viewport": {
+            "latitude": {
+                "xMin": -2.2175491067171054,
+                "xMax": 60.437532241850825
+            },
+            "longitude": {
+                "left": -170.32413020843666,
+                "right": -170.32413021843666
+            }
+        }
+      }
+    }
+
 - expectedMarkerCount: 13
   body: |
     {
@@ -231,7 +280,7 @@ bubbles:
       }
     }
 
-- expectedMarkerCount: 12
+- expectedMarkerCount: 13
   body: |
     {
         "studyId": "VBP_MEGA",

--- a/src/main/java/org/veupathdb/service/eda/merge/ServiceExternal.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/ServiceExternal.java
@@ -1,6 +1,7 @@
 package org.veupathdb.service.eda.merge;
 
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -12,6 +13,7 @@ import org.veupathdb.lib.container.jaxrs.server.annotations.DisableJackson;
 import org.veupathdb.lib.container.jaxrs.utils.RequestKeys;
 import org.veupathdb.service.eda.Resources;
 import org.veupathdb.service.eda.common.auth.StudyAccess;
+import org.veupathdb.service.eda.common.client.NonEmptyResultStream;
 import org.veupathdb.service.eda.common.model.Units;
 import org.veupathdb.service.eda.common.model.VariableDef;
 import org.veupathdb.service.eda.generated.model.*;
@@ -19,6 +21,7 @@ import org.veupathdb.service.eda.generated.resources.Merging;
 import org.veupathdb.service.eda.merge.core.MergeRequestProcessor;
 import org.veupathdb.service.eda.merge.core.request.MergedTabularRequestResources;
 import org.veupathdb.service.eda.merge.core.request.RequestResources;
+import org.veupathdb.service.eda.merge.core.stream.RootStreamingEntityNode;
 
 import java.util.Arrays;
 import java.util.List;
@@ -133,7 +136,9 @@ public class ServiceExternal implements Merging {
     catch (ValidationException e) {
       LOG.error("Invalid request", e);
       throw new BadRequestException(e.getMessage());
+    } catch (NonEmptyResultStream.EmptyResultException e) {
+      // This will be caught and handled by data service.
+      return new EntityTabularPostResponseStream(out -> LOG.info("Returning empty response."));
     }
   }
-
 }

--- a/src/main/java/org/veupathdb/service/eda/merge/core/MergeRequestProcessor.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/core/MergeRequestProcessor.java
@@ -2,6 +2,7 @@ package org.veupathdb.service.eda.merge.core;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.gusdb.fgputil.AutoCloseableList;
 import org.gusdb.fgputil.client.ResponseFuture;
 import org.gusdb.fgputil.functional.FunctionalInterfaces.ConsumerWithException;
 import org.gusdb.fgputil.functional.Functions;
@@ -77,6 +78,9 @@ public class MergeRequestProcessor {
         // all other streams come from subsetting service
         : _resources.getSubsettingTabularStream(spec);
 
+    final List<StreamSpec> requiredStreamSpecs = new ArrayList<>(requiredStreams.values());
+    AutoCloseableList<InputStream> closeableDataStreams = StreamingDataClient.buildDataStreams(requiredStreamSpecs, streamGenerator);
+
     return out -> {
 
       // create stream processor
@@ -86,7 +90,7 @@ public class MergeRequestProcessor {
           : dataStreams -> writeMergedStream(targetStream, dataStreams, out);
 
       // build and process streams
-      StreamingDataClient.buildAndProcessStreams(new ArrayList<>(requiredStreams.values()), streamGenerator, streamProcessor);
+      StreamingDataClient.processDataStreams(requiredStreamSpecs, closeableDataStreams, streamProcessor);
     };
   }
 


### PR DESCRIPTION
## Overview
Resolves https://github.com/VEuPathDB/EdaNewIssues/issues/782

Currently, we don't gracefully handle empty responses from subsetting.

We only handle empty responses from merging, which only happens when a stream is passed through merging.