### PR TITLE
Update merging/subsetting streaming interface to use CloseableIterator instead of HTTP byte stream

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/Resources.java
+++ b/src/main/java/org/veupathdb/service/eda/Resources.java
@@ -28,7 +28,13 @@ import org.veupathdb.service.eda.download.Service;
 import org.veupathdb.service.eda.merge.ServiceExternal;
 import org.veupathdb.service.eda.merge.ServiceInternal;
 import org.veupathdb.service.eda.subset.EnvironmentVars;
+import org.veupathdb.service.eda.subset.model.StudyOverview;
+import org.veupathdb.service.eda.subset.model.db.StudyFactory;
+import org.veupathdb.service.eda.subset.model.db.StudyProvider;
+import org.veupathdb.service.eda.subset.model.db.StudyResolver;
+import org.veupathdb.service.eda.subset.model.db.VariableFactory;
 import org.veupathdb.service.eda.subset.model.reducer.BinaryValuesStreamer;
+import org.veupathdb.service.eda.subset.model.reducer.MetadataFileBinaryProvider;
 import org.veupathdb.service.eda.subset.model.variable.binary.BinaryFilesManager;
 import org.veupathdb.service.eda.subset.model.variable.binary.SimpleStudyFinder;
 import org.veupathdb.service.eda.subset.service.ClearMetadataCacheService;
@@ -151,6 +157,24 @@ public class Resources extends ContainerResources {
 
   public static MetadataCache getMetadataCache() {
     return METADATA_CACHE;
+  }
+
+  public static StudyResolver getStudyResolver() {
+    final BinaryFilesManager binaryFilesManager = Resources.getBinaryFilesManager();
+    final MetadataFileBinaryProvider metadataFileBinaryProvider = new MetadataFileBinaryProvider(binaryFilesManager);
+    final VariableFactory variableFactory = new VariableFactory(Resources.getApplicationDataSource(),
+        Resources.getVdiDatasetsSchema() + ".",
+        metadataFileBinaryProvider,
+        binaryFilesManager::studyHasFiles);
+    return new StudyResolver(
+        METADATA_CACHE,
+        new StudyFactory(
+            Resources.getApplicationDataSource(),
+            Resources.getVdiDatasetsSchema() + ".",
+            StudyOverview.StudySourceType.USER_SUBMITTED,
+            variableFactory,
+            false)
+    );
   }
 
   public static boolean isFileBasedSubsettingEnabled() {

--- a/src/main/java/org/veupathdb/service/eda/Resources.java
+++ b/src/main/java/org/veupathdb/service/eda/Resources.java
@@ -28,6 +28,7 @@ import org.veupathdb.service.eda.download.Service;
 import org.veupathdb.service.eda.merge.ServiceExternal;
 import org.veupathdb.service.eda.merge.ServiceInternal;
 import org.veupathdb.service.eda.subset.EnvironmentVars;
+import org.veupathdb.service.eda.subset.model.reducer.BinaryValuesStreamer;
 import org.veupathdb.service.eda.subset.model.variable.binary.BinaryFilesManager;
 import org.veupathdb.service.eda.subset.model.variable.binary.SimpleStudyFinder;
 import org.veupathdb.service.eda.subset.service.ClearMetadataCacheService;
@@ -229,6 +230,9 @@ public class Resources extends ContainerResources {
     throw new RuntimeException("Configured data dir '" + dirPath + "' is not a readable directory.");
   }
 
+  public static BinaryValuesStreamer getBinaryValuesStreamer() {
+    return new BinaryValuesStreamer(BINARY_FILES_MANAGER, FILE_READ_THREAD_POOL, DESERIALIZER_THREAD_POOL);
+  }
 
   /**
    * Returns an array of JaxRS endpoints, providers, and contexts.

--- a/src/main/java/org/veupathdb/service/eda/common/auth/StudyAccess.java
+++ b/src/main/java/org/veupathdb/service/eda/common/auth/StudyAccess.java
@@ -2,6 +2,8 @@ package org.veupathdb.service.eda.common.auth;
 
 import jakarta.ws.rs.ForbiddenException;
 import org.json.JSONObject;
+import org.veupathdb.lib.container.jaxrs.model.User;
+import org.veupathdb.service.eda.access.service.permissions.PermissionService;
 import org.veupathdb.service.eda.common.client.DatasetAccessClient;
 
 import java.util.Map.Entry;

--- a/src/main/java/org/veupathdb/service/eda/common/auth/StudyAccess.java
+++ b/src/main/java/org/veupathdb/service/eda/common/auth/StudyAccess.java
@@ -2,8 +2,6 @@ package org.veupathdb.service.eda.common.auth;
 
 import jakarta.ws.rs.ForbiddenException;
 import org.json.JSONObject;
-import org.veupathdb.lib.container.jaxrs.model.User;
-import org.veupathdb.service.eda.access.service.permissions.PermissionService;
 import org.veupathdb.service.eda.common.client.DatasetAccessClient;
 
 import java.util.Map.Entry;

--- a/src/main/java/org/veupathdb/service/eda/common/client/EdaComputeClient.java
+++ b/src/main/java/org/veupathdb/service/eda/common/client/EdaComputeClient.java
@@ -3,17 +3,32 @@ package org.veupathdb.service.eda.common.client;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.ws.rs.core.MediaType;
+import org.gusdb.fgputil.DelimitedDataParser;
 import org.gusdb.fgputil.IoUtil;
 import org.gusdb.fgputil.client.ClientUtil;
 import org.gusdb.fgputil.client.ResponseFuture;
+import org.gusdb.fgputil.iterator.CloseableIterator;
 import org.gusdb.fgputil.json.JsonUtil;
+import org.veupathdb.service.eda.Resources;
+import org.veupathdb.service.eda.common.model.EntityDef;
+import org.veupathdb.service.eda.common.model.VariableDef;
 import org.veupathdb.service.eda.generated.model.*;
+import org.veupathdb.service.eda.merge.core.request.ComputeInfo;
+import org.veupathdb.service.eda.subset.model.Entity;
+import org.veupathdb.service.eda.subset.model.Study;
 
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.gusdb.fgputil.FormatUtil.TAB;
 
 public class EdaComputeClient {
 
@@ -66,6 +81,92 @@ public class EdaComputeClient {
 
   public <T> T getJobStatistics(String computeName, ComputeRequestBody requestBody, Class<T> expectedStatsClass) {
     return readJsonResponse(getResponseFuture(computeName, STATS_FILE_SEGMENT, requestBody), expectedStatsClass);
+  }
+
+  /**
+   * TODO migrate this to directly use compute functionality:
+   *  org.veupathdb.service.eda.compute.controller.ComputeController#resultFile(
+   *  org.veupathdb.service.eda.compute.plugins.PluginMeta, java.lang.String,
+   *  org.veupathdb.service.eda.generated.model.ComputeRequestBase, java.util.function.Function)
+   *
+   *  This isn't expected to provide a particularly noticable performance improvement, but it will avoid overhead
+   *  of HTTP.
+   */
+  public CloseableIterator<Map<String, String>> getJobTabularIteratorOutput(List<EntityDef> ancestors,
+                                                                            String computeName,
+                                                                            EntityDef computeEntity,
+                                                                            List<VariableMapping> variables,
+                                                                            ComputeRequestBody requestBody) {
+    // Construct expected headers from metadata. These are used for validation of the incoming compute stream.
+    List<String> expectedHeaders = new ArrayList<>();
+    expectedHeaders.add(computeEntity.getIdColumnDef().getVariableId());
+    ancestors.forEach(anc -> expectedHeaders.add(anc.getIdColumnDef().getVariableId()));
+    variables.forEach(var -> expectedHeaders.add(var.getVariableSpec().getVariableId()));
+
+    // Output rows should have dot-notation, so we construct the data parser with these headers.
+    List<String> outputHeaders = new ArrayList<>();
+    outputHeaders.add(toDotNotation(computeEntity.getIdColumnDef()));
+    ancestors.forEach(anc -> outputHeaders.add(toDotNotation(anc.getIdColumnDef())));
+    variables.forEach(var -> outputHeaders.add(toDotNotation(var.getVariableSpec())));
+
+    DelimitedDataParser d = new DelimitedDataParser(outputHeaders, TAB, true);
+    try {
+      InputStream is = getJobTabularOutput(computeName, requestBody).getInputStream();
+      InputStreamReader isReader = new InputStreamReader(is);
+      BufferedReader bufferedReader = new BufferedReader(isReader);
+      String headerLine = bufferedReader.readLine();
+
+      if (headerLine == null) {
+        throw new RuntimeException("Compute stream is empty.");
+      }
+
+      List<String> received = List.of(headerLine.split(TAB));
+
+      for (int i = 0; i < received.size(); i++) {
+        if (!received.get(i).equals(expectedHeaders.get(i))) { // validates header names
+
+          throw new RuntimeException("Tabular subsetting result of type '" +
+              computeEntity.getId() + "' contained unexpected header. Expected:" +
+              expectedHeaders + ". Found: " + String.join(",", received));
+        }
+      }
+
+      // Convert from InputStream to iterator.
+      return new CloseableIterator<>() {
+        private String nextLine = bufferedReader.readLine();
+
+        @Override
+        public void close() throws Exception {
+          bufferedReader.close();
+        }
+
+        @Override
+        public boolean hasNext() {
+          return nextLine != null;
+        }
+
+        @Override
+        public Map<String, String> next() {
+          Map<String, String> record = d.parseLine(nextLine);
+          try {
+            nextLine = bufferedReader.readLine();
+          } catch (IOException e) {
+            throw new RuntimeException("Failed to read from compute stream buffered reader.", e);
+          }
+          return record;
+        }
+      };
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String toDotNotation(VariableDef variableDef) {
+    return variableDef.getEntityId() + "." + variableDef.getVariableId();
+  }
+
+  private String toDotNotation(VariableSpec variableSpec) {
+    return variableSpec.getEntityId() + "." + variableSpec.getVariableId();
   }
 
   public ResponseFuture getJobTabularOutput(String computeName, ComputeRequestBody requestBody) {

--- a/src/main/java/org/veupathdb/service/eda/common/client/EdaSubsettingClient.java
+++ b/src/main/java/org/veupathdb/service/eda/common/client/EdaSubsettingClient.java
@@ -6,6 +6,7 @@ import org.gusdb.fgputil.client.ClientUtil;
 import org.gusdb.fgputil.client.ResponseFuture;
 import org.gusdb.fgputil.json.JsonUtil;
 import org.gusdb.fgputil.web.MimeTypes;
+import org.veupathdb.service.eda.Resources;
 import org.veupathdb.service.eda.common.client.spec.EdaSubsettingSpecValidator;
 import org.veupathdb.service.eda.common.client.spec.StreamSpec;
 import org.veupathdb.service.eda.common.client.spec.StreamSpecValidator;
@@ -14,6 +15,7 @@ import org.veupathdb.service.eda.common.model.ReferenceMetadata;
 import org.veupathdb.service.eda.common.model.VariableDef;
 import org.veupathdb.service.eda.common.model.VariableSource;
 import org.veupathdb.service.eda.generated.model.*;
+import org.veupathdb.service.eda.subset.service.ApiConversionUtil;
 
 import java.io.InputStream;
 import java.util.HashMap;
@@ -50,12 +52,7 @@ public class EdaSubsettingClient extends StreamingDataClient {
    * @return optional study detail for the found study
    */
   public Optional<APIStudyDetail> getStudy(String studyId) {
-    if (!getStudies().contains(studyId)) return Optional.empty(); // invalid name
-    if (!_studyDetailCache.containsKey(studyId)) {
-      _studyDetailCache.put(studyId, swallowAndGet(() -> ClientUtil
-          .getResponseObject(getUrl("/studies/" + studyId), StudyIdGetResponse.class, getAuthHeaderMap()).getStudy()));
-    }
-    return Optional.of(_studyDetailCache.get(studyId));
+    return Optional.of(ApiConversionUtil.getApiStudyDetail(Resources.getMetadataCache().getStudyById(studyId)));
   }
 
   @Override

--- a/src/main/java/org/veupathdb/service/eda/common/client/StreamingDataClient.java
+++ b/src/main/java/org/veupathdb/service/eda/common/client/StreamingDataClient.java
@@ -4,10 +4,13 @@ import java.io.InputStream;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import jakarta.ws.rs.ProcessingException;
 import org.gusdb.fgputil.AutoCloseableList;
 import org.gusdb.fgputil.client.ResponseFuture;
 import org.gusdb.fgputil.functional.FunctionalInterfaces;
+import org.gusdb.fgputil.iterator.CloseableIterator;
 import org.veupathdb.service.eda.common.client.spec.StreamSpec;
 import org.veupathdb.service.eda.common.client.spec.StreamSpecValidator;
 import org.veupathdb.service.eda.common.model.ReferenceMetadata;
@@ -38,6 +41,23 @@ public abstract class StreamingDataClient extends ServiceClient {
     AutoCloseableList<InputStream> dataStreams = buildDataStreams(requiredStreams, streamGenerator);
     processDataStreams(requiredStreams, dataStreams, streamProcessor);
   }
+
+  public static void buildAndProcessIteratorStreams(ArrayList<StreamSpec> requiredStreams,
+                                                    Function<StreamSpec, CloseableIterator<Map<String, String>>> streamGenerator,
+                                                    FunctionalInterfaces.ConsumerWithException<Map<String, CloseableIterator<Map<String, String>>>> streamProcessor) {
+    try (AutoCloseableList<CloseableIterator<Map<String, String>>> streams = new AutoCloseableList<>(requiredStreams.stream()
+        .map(streamGenerator)
+        .collect(Collectors.toList()))) {
+      // convert auto-closeable list into a named stream map for processing
+      Map<String, CloseableIterator<Map<String, String>>> streamMap = new LinkedHashMap<>();
+
+      for (int i = 0; i < streams.size(); i++) {
+        streamMap.put(requiredStreams.get(i).getStreamName(), streams.get(i));
+      }
+      cSwallow(streamProcessor).accept(streamMap);
+    }
+  }
+
 
   public static void processDataStreams(
       List<StreamSpec> requiredStreams,

--- a/src/main/java/org/veupathdb/service/eda/data/core/AbstractPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/core/AbstractPlugin.java
@@ -183,7 +183,6 @@ public abstract class AbstractPlugin<T extends DataPluginRequestBase, S, R> {
     Function<StreamSpec, ResponseFuture> streamGenerator = spec -> _mergingClient
         .getTabularDataStream(_referenceMetadata, _subsetFilters, _derivedVariableSpecs, typedTuple, spec);
 
-    StreamingDataClient.buildAndProcessIteratorStreams(_requiredStreams, );
     final AutoCloseableList<InputStream> dataStreams = StreamingDataClient.buildDataStreams(_requiredStreams, streamGenerator);
 
     return out -> {

--- a/src/main/java/org/veupathdb/service/eda/data/core/AbstractPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/core/AbstractPlugin.java
@@ -183,6 +183,7 @@ public abstract class AbstractPlugin<T extends DataPluginRequestBase, S, R> {
     Function<StreamSpec, ResponseFuture> streamGenerator = spec -> _mergingClient
         .getTabularDataStream(_referenceMetadata, _subsetFilters, _derivedVariableSpecs, typedTuple, spec);
 
+    StreamingDataClient.buildAndProcessIteratorStreams(_requiredStreams, );
     final AutoCloseableList<InputStream> dataStreams = StreamingDataClient.buildDataStreams(_requiredStreams, streamGenerator);
 
     return out -> {

--- a/src/main/java/org/veupathdb/service/eda/merge/ServiceExternal.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/ServiceExternal.java
@@ -91,11 +91,10 @@ public class ServiceExternal implements Merging {
   @DisableJackson
   @Override
   public PostMergingQueryResponse postMergingQuery(MergedEntityTabularPostRequest requestBody) {
-
     // check access to full tabular results since this endpoint is intended to be exposed through traefik
-//    Entry<String,String> authHeader = checkPermissions(getAuthHeader(_request), requestBody.getStudyId());
+    Entry<String,String> authHeader = checkPermissions(getAuthHeader(_request), requestBody.getStudyId());
     // TODO Remove auth header once compute interface is intra-process (not over http).
-    return PostMergingQueryResponse.respond200WithTextTabSeparatedValues(processMergedTabularRequest(requestBody, getAuthHeader(_request)));
+    return PostMergingQueryResponse.respond200WithTextTabSeparatedValues(processMergedTabularRequest(requestBody, authHeader));
   }
 
 

--- a/src/main/java/org/veupathdb/service/eda/merge/ServiceExternal.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/ServiceExternal.java
@@ -91,9 +91,11 @@ public class ServiceExternal implements Merging {
   @DisableJackson
   @Override
   public PostMergingQueryResponse postMergingQuery(MergedEntityTabularPostRequest requestBody) {
+
     // check access to full tabular results since this endpoint is intended to be exposed through traefik
-    Entry<String,String> authHeader = checkPermissions(getAuthHeader(_request), requestBody.getStudyId());
-    return PostMergingQueryResponse.respond200WithTextTabSeparatedValues(processMergedTabularRequest(requestBody, authHeader));
+//    Entry<String,String> authHeader = checkPermissions(getAuthHeader(_request), requestBody.getStudyId());
+    // TODO Remove auth header once compute interface is intra-process (not over http).
+    return PostMergingQueryResponse.respond200WithTextTabSeparatedValues(processMergedTabularRequest(requestBody, getAuthHeader(_request)));
   }
 
 

--- a/src/main/java/org/veupathdb/service/eda/merge/core/MergeRequestProcessor.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/core/MergeRequestProcessor.java
@@ -2,11 +2,12 @@ package org.veupathdb.service.eda.merge.core;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.gusdb.fgputil.client.ResponseFuture;
 import org.gusdb.fgputil.functional.FunctionalInterfaces.ConsumerWithException;
 import org.gusdb.fgputil.functional.Functions;
+import org.gusdb.fgputil.iterator.CloseableIterator;
 import org.gusdb.fgputil.iterator.IteratorUtil;
 import org.gusdb.fgputil.validation.ValidationException;
+import org.veupathdb.service.eda.Resources;
 import org.veupathdb.service.eda.common.client.StreamingDataClient;
 import org.veupathdb.service.eda.common.client.spec.StreamSpec;
 import org.veupathdb.service.eda.common.model.EntityDef;
@@ -16,12 +17,17 @@ import org.veupathdb.service.eda.generated.model.VariableSpec;
 import org.veupathdb.service.eda.merge.core.request.ComputeInfo;
 import org.veupathdb.service.eda.merge.core.request.MergedTabularRequestResources;
 import org.veupathdb.service.eda.merge.core.stream.RootStreamingEntityNode;
+import org.veupathdb.service.eda.subset.model.Study;
+import org.veupathdb.service.eda.subset.model.db.FilteredResultFactory;
+import org.veupathdb.service.eda.subset.model.variable.VariableWithValues;
+import org.veupathdb.service.eda.subset.service.ApiConversionUtil;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.gusdb.fgputil.FormatUtil.TAB;
 import static org.veupathdb.service.eda.merge.core.stream.RootStreamingEntityNode.COMPUTED_VAR_STREAM_NAME;
@@ -55,6 +61,7 @@ public class MergeRequestProcessor {
     List<VariableSpec> outputVarSpecs = _resources.getOutputVariableSpecs();
     ReferenceMetadata metadata = _resources.getMetadata();
     Optional<ComputeInfo> computeInfo = _resources.getComputeInfo();
+    Study study = Resources.getMetadataCache().getStudyById(_resources.getMetadata().getStudyId());
 
     // request validated; convert requested entity and vars to defs
     EntityDef targetEntity = metadata.getEntity(targetEntityId).orElseThrow();
@@ -66,54 +73,45 @@ public class MergeRequestProcessor {
         _resources.getSubsetFilters(), metadata, _resources.getDerivedVariableFactory(), computeInfo);
     LOG.info("Created the following entity node tree: " + targetStream);
 
+    final boolean fileBasedSubsetting = Resources.isFileBasedSubsettingEnabled() && Resources.getMetadataCache().studyHasFiles(study.getStudyId());
+
     // get stream specs for streams needed by the node tree, which will be merged into this request's response
     Map<String, StreamSpec> requiredStreams = Functions.getMapFromValues(targetStream.getRequiredStreamSpecs(), StreamSpec::getStreamName);
 
     // create stream generator
-    Function<StreamSpec, ResponseFuture> streamGenerator = spec ->
+    Function<StreamSpec, CloseableIterator<Map<String, String>>> streamGenerator = spec ->
         COMPUTED_VAR_STREAM_NAME.equals(spec.getStreamName())
         // need to get compute stream from compute service
-        ? _resources.getComputeTabularStream()
+        ? _resources.getComputeStreamIterator(study)
         // all other streams come from subsetting service
-        : _resources.getSubsettingTabularStream(spec);
+        : FilteredResultFactory.tabularSubsetIterator(study,
+        study.getEntity(spec.getEntityId()).orElseThrow(),
+        spec.stream()
+            .map(varSpec -> study.getEntity(spec.getEntityId()).orElseThrow().getVariableOrThrow(varSpec.getVariableId()))
+            .map(var -> (VariableWithValues) var)
+            .collect(Collectors.toList()),
+            ApiConversionUtil.toInternalFilters(study, spec.getFiltersOverride().orElse(_resources.getSubsetFilters()), Resources.getAppDbSchema()), // Move this up?
+            Resources.getBinaryValuesStreamer(), fileBasedSubsetting, Resources.getApplicationDataSource(), Resources.getAppDbSchema());
 
     return out -> {
 
       // create stream processor
-      ConsumerWithException<Map<String,InputStream>> streamProcessor =
-          targetStream.requiresNoDataManipulation()
-          ? dataStreams -> writePassThroughStream(outputVars, dataStreams.values().iterator().next(), out)
-          : dataStreams -> writeMergedStream(targetStream, dataStreams, out);
+      ConsumerWithException<Map<String, CloseableIterator<Map<String, String>>>> streamProcessor =
+          dataStreams -> writeMergedStream(targetStream, dataStreams, out);
 
       // build and process streams
-      StreamingDataClient.buildAndProcessStreams(new ArrayList<>(requiredStreams.values()), streamGenerator, streamProcessor);
+      StreamingDataClient.buildAndProcessIteratorStreams(new ArrayList<>(requiredStreams.values()), streamGenerator, streamProcessor);
     };
   }
 
-  private static void writePassThroughStream(List<VariableSpec> outputVars, InputStream in, OutputStream out) {
-    try (BufferedInputStream is = new BufferedInputStream(in);
-         BufferedOutputStream os = new BufferedOutputStream(out)) {
-      do {
-        // Skip over header line to re-write with dot notation.
-      } while (is.read() != '\n');
-      String headerRow = String.join(TAB, VariableDef.toDotNotation(outputVars));
-      os.write(headerRow.getBytes(StandardCharsets.UTF_8));
-      os.write('\n');
-
-      LOG.info("Transferring subsetting stream to output since there is only one stream.");
-      is.transferTo(os);
-    }
-    catch (IOException e) {
-      throw new RuntimeException("Unable to write output stream", e);
-    }
-  }
-
-  private static void writeMergedStream(RootStreamingEntityNode targetEntityStream, Map<String, InputStream> dataStreams, OutputStream out) {
+  private static void writeMergedStream(RootStreamingEntityNode targetEntityStream,
+                                        Map<String, CloseableIterator<Map<String, String>>> dataStreams,
+                                        OutputStream out) {
 
     LOG.info("All requested streams (" + dataStreams.size() + ") ready for consumption");
 
     // distribute the streams to their processors and make sure they all get claimed
-    Map<String, InputStream> distributionMap = new HashMap<>(dataStreams); // make a copy which will get cleared out
+    Map<String, CloseableIterator<Map<String, String>>> distributionMap = new HashMap<>(dataStreams); // make a copy which will get cleared out
     targetEntityStream.acceptDataStreams(distributionMap);
     if (!distributionMap.isEmpty())
       throw new IllegalStateException("Not all requested data streams were claimed by the processor tree.  " +

--- a/src/main/java/org/veupathdb/service/eda/merge/core/MergeRequestProcessor.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/core/MergeRequestProcessor.java
@@ -60,7 +60,7 @@ public class MergeRequestProcessor {
     List<VariableSpec> outputVarSpecs = _resources.getOutputVariableSpecs();
     ReferenceMetadata metadata = _resources.getMetadata();
     Optional<ComputeInfo> computeInfo = _resources.getComputeInfo();
-    Study study = Resources.getMetadataCache().getStudyById(_resources.getMetadata().getStudyId());
+    Study study = Resources.getStudyResolver().getStudyById(_resources.getMetadata().getStudyId());
 
     // request validated; convert requested entity and vars to defs
     EntityDef targetEntity = metadata.getEntity(targetEntityId).orElseThrow();
@@ -71,6 +71,7 @@ public class MergeRequestProcessor {
         _resources.getSubsetFilters(), metadata, _resources.getDerivedVariableFactory(), computeInfo);
     LOG.info("Created the following entity node tree: " + targetStream);
 
+    // Use metadata cache directly, which bypasses user studies, since user studies don't currently have files.
     final boolean fileBasedSubsetting = Resources.getMetadataCache().studyHasFiles(study.getStudyId());
 
     // get stream specs for streams needed by the node tree, which will be merged into this request's response

--- a/src/main/java/org/veupathdb/service/eda/merge/core/MergeRequestProcessor.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/core/MergeRequestProcessor.java
@@ -66,14 +66,13 @@ public class MergeRequestProcessor {
     // request validated; convert requested entity and vars to defs
     EntityDef targetEntity = metadata.getEntity(targetEntityId).orElseThrow();
     List<VariableDef> outputVarDefs = metadata.getTabularColumns(targetEntity, outputVarSpecs);
-    List<VariableSpec> outputVars = new ArrayList<>(outputVarDefs.stream().map(v -> (VariableSpec)v).toList());
 
     // build entity node tree to aggregate the data into a streaming response
     RootStreamingEntityNode targetStream = new RootStreamingEntityNode(targetEntity, outputVarDefs,
         _resources.getSubsetFilters(), metadata, _resources.getDerivedVariableFactory(), computeInfo);
     LOG.info("Created the following entity node tree: " + targetStream);
 
-    final boolean fileBasedSubsetting = Resources.isFileBasedSubsettingEnabled() && Resources.getMetadataCache().studyHasFiles(study.getStudyId());
+    final boolean fileBasedSubsetting = Resources.getMetadataCache().studyHasFiles(study.getStudyId());
 
     // get stream specs for streams needed by the node tree, which will be merged into this request's response
     Map<String, StreamSpec> requiredStreams = Functions.getMapFromValues(targetStream.getRequiredStreamSpecs(), StreamSpec::getStreamName);

--- a/src/main/java/org/veupathdb/service/eda/merge/core/request/MergedTabularRequestResources.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/core/request/MergedTabularRequestResources.java
@@ -55,7 +55,6 @@ public class MergedTabularRequestResources extends RequestResources {
     _computeInfo = Optional.ofNullable(request.getComputeSpec())
         .map(spec -> new ComputeInfo(spec.getComputeName(),
             new EdaComputeClient.ComputeRequestBody(_metadata.getStudyId(), _subsetFilters, _derivedVariableSpecs, spec.getComputeConfig())));
-
     // incorporate computed metadata (if compute info present)
     incorporateCompute();
 
@@ -153,7 +152,7 @@ public class MergedTabularRequestResources extends RequestResources {
       }
     }
   }
-
+  
   public ResponseFuture getSubsettingTabularStream(StreamSpec spec) {
 
     // for derived var plugins, need to ensure filters overrides produce set of rows which are a subset of the rows

--- a/src/main/java/org/veupathdb/service/eda/merge/core/request/RequestResources.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/core/request/RequestResources.java
@@ -12,6 +12,7 @@ import org.veupathdb.service.eda.generated.model.DerivedVariableSpec;
 import org.veupathdb.service.eda.Resources;
 import org.veupathdb.service.eda.merge.core.derivedvars.DerivedVariable;
 import org.veupathdb.service.eda.merge.core.derivedvars.DerivedVariableFactory;
+import org.veupathdb.service.eda.subset.service.MetadataCache;
 
 import java.util.List;
 import java.util.Map.Entry;

--- a/src/main/java/org/veupathdb/service/eda/merge/core/stream/EntityStream.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/core/stream/EntityStream.java
@@ -3,6 +3,7 @@ package org.veupathdb.service.eda.merge.core.stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.gusdb.fgputil.DelimitedDataParser;
+import org.gusdb.fgputil.iterator.CloseableIterator;
 import org.gusdb.fgputil.json.JsonUtil;
 import org.veupathdb.service.eda.common.client.spec.StreamSpec;
 import org.veupathdb.service.eda.common.model.EntityDef;
@@ -49,7 +50,7 @@ public class EntityStream implements Iterator<Map<String,String>> {
   private StreamSpec _streamSpec;
   private String _entityIdColumnName;
   private List<VariableDef> _expectedNativeColumns;
-  private DelimitedDataParser _parser;
+  private CloseableIterator<Map<String, String>> _dataStream;
 
   // fields set up by the assignment of the data stream
   // caches the last row read from the scanner (null if no more rows)
@@ -68,7 +69,6 @@ public class EntityStream implements Iterator<Map<String,String>> {
     _entityIdColumnName = VariableDef.toDotNotation(entity.getIdColumnDef());
     _expectedNativeColumns = _metadata.getTabularColumns(entity, streamSpec);
     List<String> nativeHeaders = VariableDef.toDotNotation(_expectedNativeColumns);
-    _parser = new DelimitedDataParser(nativeHeaders, TAB, true);
     return this;
   }
 
@@ -80,40 +80,13 @@ public class EntityStream implements Iterator<Map<String,String>> {
     return _entityIdColumnName;
   }
 
-  public void acceptDataStreams(Map<String, InputStream> dataStreams) {
-    InputStream inStream = dataStreams.get(_streamSpec.getStreamName());
-    if (inStream == null) // not found!
+  public void acceptDataStreams(Map<String, CloseableIterator<Map<String, String>>> dataStreams) {
+    _dataStream = dataStreams.get(_streamSpec.getStreamName());
+    if (_dataStream == null) // not found!
       throw new IllegalStateException("Stream with name " + _streamSpec.getStreamName() + " expected but not distributed.");
     // remove the stream from the map; then enables later checking of whether all streams were distributed
     dataStreams.remove(_streamSpec.getStreamName());
-    _reader = beginValidatedInput(inStream);
     _lastRowRead = readRow();
-  }
-
-  private BufferedReader beginValidatedInput(InputStream inStream) {
-    final InputStreamReader inputStreamReader = new InputStreamReader(inStream);
-    final BufferedReader reader = new BufferedReader(inputStreamReader);
-    try {
-      final String headerLine = reader.readLine();
-      // capture the header and validate response
-      if (headerLine == null) {
-        throw new RuntimeException("Subsetting service tabular endpoint did not return header row");
-      }
-      Map<String,String> header = _parser.parseLine(headerLine); // validates counts
-      List<String> received = new ArrayList<>(header.values());
-      for (int i = 0; i < received.size(); i++) {
-        if (!received.get(i).equals(_expectedNativeColumns.get(i).getVariableId())) { // validates header names
-          throw new RuntimeException("Tabular subsetting result of type '" +
-              _streamSpec.getEntityId() + "' contained unexpected header." + NL + "Expected:" +
-              _expectedNativeColumns.stream().map(VariableSpecImpl::getVariableId).collect(Collectors.joining(",")) +
-              NL + "Found   : " + String.join(",", received));
-        }
-      }
-      return reader;
-    }
-    catch (IOException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   /**
@@ -130,13 +103,7 @@ public class EntityStream implements Iterator<Map<String,String>> {
 
   // returns null if no more rows
   private Map<String, String> readRow() {
-    try {
-      final String nextLine = _reader.readLine();
-      return nextLine == null ? null : applyDerivedVars(_parser.parseLine(nextLine));
-    }
-    catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    return !_dataStream.hasNext() ? null : applyDerivedVars(_dataStream.next());
   }
 
   @Override

--- a/src/main/java/org/veupathdb/service/eda/merge/core/stream/EntityStream.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/core/stream/EntityStream.java
@@ -68,7 +68,6 @@ public class EntityStream implements Iterator<Map<String,String>> {
     // cache the name of the column used to identify records that match the current row
     _entityIdColumnName = VariableDef.toDotNotation(entity.getIdColumnDef());
     _expectedNativeColumns = _metadata.getTabularColumns(entity, streamSpec);
-    List<String> nativeHeaders = VariableDef.toDotNotation(_expectedNativeColumns);
     return this;
   }
 

--- a/src/main/java/org/veupathdb/service/eda/merge/core/stream/RootStreamingEntityNode.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/core/stream/RootStreamingEntityNode.java
@@ -163,7 +163,7 @@ public class RootStreamingEntityNode extends StreamingEntityNode {
       // make sure ID matches
       if (!row.get(getEntityIdColumnName()).equals(nextComputedRow.get(getEntityIdColumnName()))) {
         throw new IllegalStateException("Computed row entity ID '" + nextComputedRow.get(getEntityIdColumnName()) +
-            " does not match expected ID " + row.get(getEntityIdColumnName()));
+            " does not match expected ID " + row.get(getEntityIdColumnName()) + ". Row: " + row + ". Computed: " + new HashMap<>(nextComputedRow));
       }
       // add values to row
       row.putAll(nextComputedRow);

--- a/src/main/java/org/veupathdb/service/eda/merge/core/stream/RootStreamingEntityNode.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/core/stream/RootStreamingEntityNode.java
@@ -3,6 +3,7 @@ package org.veupathdb.service.eda.merge.core.stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.gusdb.fgputil.collection.InitialSizeStringMap;
+import org.gusdb.fgputil.iterator.CloseableIterator;
 import org.gusdb.fgputil.json.JsonUtil;
 import org.gusdb.fgputil.validation.ValidationException;
 import org.veupathdb.service.eda.common.client.spec.StreamSpec;
@@ -42,7 +43,7 @@ public class RootStreamingEntityNode extends StreamingEntityNode {
   public static final String COMPUTED_VAR_STREAM_NAME = "__COMPUTED_VAR_STREAM__";
 
   private final String[] _outputVars;
-  private final InitialSizeStringMap _outputRow;
+  private final InitialSizeStringMap.Builder _outputRowBuilder;
 
   private final Optional<EntityStream> _computeStreamProcessor;
   private final boolean _computeEntityMatchesOurs;
@@ -68,7 +69,7 @@ public class RootStreamingEntityNode extends StreamingEntityNode {
 
     _outputVars = getOrderedOutputColumns(fullOutputVarDefs);
     LOG.info("Root stream final output vars: " + String.join(", ", _outputVars));
-    _outputRow = new InitialSizeStringMap.Builder(_outputVars).build();
+    _outputRowBuilder = new InitialSizeStringMap.Builder(_outputVars);
   }
 
   private String[] getOrderedOutputColumns(List<VariableSpec> fullOutputVarDefs) throws ValidationException {
@@ -123,7 +124,7 @@ public class RootStreamingEntityNode extends StreamingEntityNode {
   }
 
   @Override
-  public void acceptDataStreams(Map<String, InputStream> dataStreams) {
+  public void acceptDataStreams(Map<String, CloseableIterator<Map<String, String>>> dataStreams) {
     _computeStreamProcessor.ifPresent(s -> s.acceptDataStreams(dataStreams));
     super.acceptDataStreams(dataStreams);
   }
@@ -139,11 +140,14 @@ public class RootStreamingEntityNode extends StreamingEntityNode {
     _computeStreamProcessor.ifPresent(computeStream -> applyCompute(row, computeStream));
 
     // return only requested vars and in the correct order
-    _outputRow.clear();
+    final InitialSizeStringMap outputRow = _outputRowBuilder.build();
+    final String[] outputVals = new String[_outputVars.length];
+    int i = 0;
     for (String col : _outputVars) {
-      _outputRow.put(col, row.get(col));
+      outputVals[i++] = row.get(col);
     }
-    return _outputRow;
+    outputRow.putAll(outputVals);
+    return outputRow;
   }
 
   private void applyCompute(Map<String, String> row, EntityStream computeStream) {

--- a/src/main/java/org/veupathdb/service/eda/merge/core/stream/RootStreamingEntityNode.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/core/stream/RootStreamingEntityNode.java
@@ -163,7 +163,7 @@ public class RootStreamingEntityNode extends StreamingEntityNode {
       // make sure ID matches
       if (!row.get(getEntityIdColumnName()).equals(nextComputedRow.get(getEntityIdColumnName()))) {
         throw new IllegalStateException("Computed row entity ID '" + nextComputedRow.get(getEntityIdColumnName()) +
-            " does not match expected ID " + row.get(getEntityIdColumnName()) + ". Row: " + row + ". Computed: " + new HashMap<>(nextComputedRow));
+            " does not match expected ID " + row.get(getEntityIdColumnName()));
       }
       // add values to row
       row.putAll(nextComputedRow);

--- a/src/main/java/org/veupathdb/service/eda/merge/core/stream/StreamingEntityNode.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/core/stream/StreamingEntityNode.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.gusdb.fgputil.Tuples.TwoTuple;
 import org.gusdb.fgputil.functional.Functions;
+import org.gusdb.fgputil.iterator.CloseableIterator;
 import org.gusdb.fgputil.validation.ValidationException;
 import org.veupathdb.service.eda.common.client.spec.StreamSpec;
 import org.veupathdb.service.eda.merge.core.derivedvars.DerivedVariableFactory;
@@ -169,7 +170,7 @@ public class StreamingEntityNode extends EntityStream {
   }
 
   @Override
-  public void acceptDataStreams(Map<String, InputStream> dataStreams) {
+  public void acceptDataStreams(Map<String, CloseableIterator<Map<String, String>>> dataStreams) {
     // order matters here; incoming data must be initialized before this node
     //   initializes its first row or required columns will not be present
     _ancestorStreams.forEach(s -> s.acceptDataStreams(dataStreams));

--- a/src/main/java/org/veupathdb/service/eda/subset/service/MetadataCache.java
+++ b/src/main/java/org/veupathdb/service/eda/subset/service/MetadataCache.java
@@ -69,7 +69,7 @@ public class MetadataCache implements StudyProvider {
     return Collections.unmodifiableList(_studyOverviews);
   }
 
-  private synchronized boolean studyHasFiles(String studyAbbrev) {
+  public synchronized boolean studyHasFiles(String studyAbbrev) {
     _studyHasFilesCache.computeIfAbsent(studyAbbrev, _binaryFilesManager::studyHasFiles);
     return _studyHasFilesCache.get(studyAbbrev);
   }

--- a/src/main/java/org/veupathdb/service/eda/subset/service/StudiesService.java
+++ b/src/main/java/org/veupathdb/service/eda/subset/service/StudiesService.java
@@ -92,7 +92,7 @@ public class StudiesService implements Studies {
     Set<String> visibleStudyIds = visibleStudyMap.keySet();
 
     // filter overviews by visible studies
-    Map<String, StudyOverview> visibleOverviewMap = getStudyResolver()
+    Map<String, StudyOverview> visibleOverviewMap = Resources.getStudyResolver()
         .getStudyOverviews().stream()
         .filter(overview -> visibleStudyIds.contains(overview.getStudyId()))
         .collect(Collectors.toMap(StudyOverview::getStudyId, Function.identity()));
@@ -106,7 +106,7 @@ public class StudiesService implements Studies {
   @Override
   public GetStudiesByStudyIdResponse getStudiesByStudyId(String studyId) {
     checkPerms(_request, studyId, StudyAccess::allowStudyMetadata);
-    Study study = getStudyResolver().getStudyById(studyId);
+    Study study = Resources.getStudyResolver().getStudyById(studyId);
     APIStudyDetail apiStudyDetail = ApiConversionUtil.getApiStudyDetail(study);
     StudyIdGetResponse response = new StudyIdGetResponseImpl();
     response.setStudy(apiStudyDetail);
@@ -116,7 +116,7 @@ public class StudiesService implements Studies {
   @Override
   public GetStudiesEntitiesByStudyIdAndEntityIdResponse getStudiesEntitiesByStudyIdAndEntityId(String studyId, String entityId) {
     checkPerms(_request, studyId, StudyAccess::allowStudyMetadata);
-    APIStudyDetail apiStudyDetail = ApiConversionUtil.getApiStudyDetail(getStudyResolver().getStudyById(studyId));
+    APIStudyDetail apiStudyDetail = ApiConversionUtil.getApiStudyDetail(Resources.getStudyResolver().getStudyById(studyId));
     APIEntity entity = findEntityById(apiStudyDetail.getRootEntity(), entityId).orElseThrow(NotFoundException::new);
     EntityIdGetResponse response = new EntityIdGetResponseImpl();
     // copy properties of found entity, skipping children
@@ -146,7 +146,7 @@ public class StudiesService implements Studies {
   public static VariableDistributionPostResponse handleDistributionRequest(
       String studyId, String entityId, String variableId, VariableDistributionPostRequest request) {
     try {
-      Study study = getStudyResolver().getStudyById(studyId);
+      Study study = Resources.getStudyResolver().getStudyById(studyId);
       String dataSchema = resolveSchema(study);
 
       // unpack data from API input to model objects
@@ -194,7 +194,7 @@ public class StudiesService implements Studies {
       PostStudiesEntitiesTabularByStudyIdAndEntityIdResponse typedResponse =
           postStudiesEntitiesTabularByStudyIdAndEntityId(studyId, entityId, request);
       // success so far; add header to response
-      String entityDisplay = getStudyResolver().getStudyById(studyId).getEntity(entityId).orElseThrow().getDisplayName();
+      String entityDisplay = Resources.getStudyResolver().getStudyById(studyId).getEntity(entityId).orElseThrow().getDisplayName();
       String fileName = studyId + "_" + entityDisplay + "_subsettedData.txt";
       String dispositionHeaderValue = "attachment; filename=\"" + fileName + "\"";
       ServiceMetrics.reportSubsetDownload(studyId, UserProvider.lookupUser(_request)
@@ -213,7 +213,7 @@ public class StudiesService implements Studies {
   @Override
   public PostStudiesEntitiesVariablesRootVocabByStudyIdAndEntityIdAndVariableIdResponse postStudiesEntitiesVariablesRootVocabByStudyIdAndEntityIdAndVariableId(String studyId, String entityId, String variableId, VocabByRootEntityPostRequest body) {
     checkPerms(_request, studyId, StudyAccess::allowSubsetting);
-    Study study = getStudyResolver().getStudyById(studyId);
+    Study study = Resources.getStudyResolver().getStudyById(studyId);
     String dataSchema = resolveSchema(study);
 
 
@@ -262,7 +262,7 @@ public class StudiesService implements Studies {
       EntityTabularPostRequest requestBody, boolean checkUserPermissions,
       BiFunction<EntityTabularPostResponseStream,TabularResponses.Type,T> responseConverter) {
     LOG.debug("Handling tabular request for study {} and entity {}.", studyId, entityId);
-    Study study = getStudyResolver().getStudyById(studyId);
+    Study study = Resources.getStudyResolver().getStudyById(studyId);
     String dataSchema = resolveSchema(study);
     RequestBundle request = RequestBundle.unpack(dataSchema, study, entityId, requestBody.getFilters(), requestBody.getOutputVariableIds(), requestBody.getReportConfig());
 
@@ -331,7 +331,7 @@ public class StudiesService implements Studies {
       return false;
     }
 
-    if (!binaryFilesManager.studyHasFiles(requestBundle.getStudy())) {
+    if (!binaryFilesManager.studyHasCompatibleFiles(requestBundle.getStudy())) {
       LOG.debug("Unable to find study dir for " + requestBundle.getStudy().getStudyId() + " in study files.");
       return false;
     }
@@ -377,7 +377,7 @@ public class StudiesService implements Studies {
 
   public static EntityCountPostResponse handleCountRequest(String studyId, String entityId, EntityCountPostRequest rawRequest) {
     LOG.info("Handling count request with filters: {}", () -> JsonUtil.serializeObject(rawRequest.getFilters()));
-    Study study = getStudyResolver().getStudyById(studyId);
+    Study study = Resources.getStudyResolver().getStudyById(studyId);
     String dataSchema = resolveSchema(study);
 
     // unpack data from API input to model objects
@@ -410,25 +410,6 @@ public class StudiesService implements Studies {
   private static void checkPerms(ContainerRequest request, String studyId, Predicate<StudyAccess> accessPredicate) {
     Entry<String, String> authHeader = UserProvider.getSubmittedAuth(request).orElseThrow();
     StudyAccess.confirmPermission(authHeader, Resources.getDatasetAccessServiceUrl(), studyId, accessPredicate);
-  }
-
-
-  private static StudyProvider getStudyResolver() {
-    final BinaryFilesManager binaryFilesManager = Resources.getBinaryFilesManager();
-    final MetadataFileBinaryProvider metadataFileBinaryProvider = new MetadataFileBinaryProvider(binaryFilesManager);
-    final VariableFactory variableFactory = new VariableFactory(Resources.getApplicationDataSource(),
-        Resources.getVdiDatasetsSchema() + ".",
-        metadataFileBinaryProvider,
-        binaryFilesManager::studyHasFiles);
-    return new StudyResolver(
-        Resources.getMetadataCache(),
-        new StudyFactory(
-            Resources.getApplicationDataSource(),
-            Resources.getVdiDatasetsSchema() + ".",
-            StudyOverview.StudySourceType.USER_SUBMITTED,
-            variableFactory,
-            false)
-    );
   }
 
   private static String resolveSchema(Study study) {

--- a/src/main/java/org/veupathdb/service/eda/subset/service/StudiesService.java
+++ b/src/main/java/org/veupathdb/service/eda/subset/service/StudiesService.java
@@ -336,16 +336,6 @@ public class StudiesService implements Studies {
       return false;
     }
 
-    final Long dataVersion = binaryFilesManager.getDataVersionUsed(requestBundle.getStudy());
-    if (dataVersion == null) {
-      LOG.info("No data version found, falling back to database");
-      return false;
-    }
-    if (binaryFilesManager.getDataVersionUsed(requestBundle.getStudy()) != requestBundle.getStudy().getLastModified().getTime()) {
-      LOG.info("Data version does not match last modified time of study. Data version: " + dataVersion + ". Study last modified "
-          + requestBundle.getStudy().getLastModified().getTime());
-      return false;
-    }
     if (!binaryFilesManager.entityDirExists(requestBundle.getStudy(), requestBundle.getTargetEntity())) {
       LOG.debug("Unable to find entity dir for " + requestBundle.getTargetEntity().getId() + " in study files.");
       return false;

--- a/src/main/java/org/veupathdb/service/eda/subset/service/StudiesService.java
+++ b/src/main/java/org/veupathdb/service/eda/subset/service/StudiesService.java
@@ -319,12 +319,6 @@ public class StudiesService implements Studies {
    * 3. Any data is missing in files (i.e. MissingDataException is thrown).
    **/
   private static boolean shouldRunFileBasedSubsetting(RequestBundle requestBundle, BinaryFilesManager binaryFilesManager) {
-  /*  ignore env var (set to false in qa and prod)
-    if (!Resources.isFileBasedSubsettingEnabled()) {
-      LOG.info("Can't use files because: Env var FILE_SUBSETTING_ENABLED=false");
-      return false;
-    }
-  */
     LOG.debug("Determining whether to use file-based subsetting in request for study '" +
         requestBundle.getStudy().getStudyId() + "', entity '" + requestBundle.getTargetEntity() + "'.");
 


### PR DESCRIPTION
## Overview
This change removes overhead of writing serialized subsetting rows as bytes to an `OutputStream` and re-serializing them.

I ran map regression tests, I'm still working on writing some compute tests.