### PR TITLE
New constraints for standalone map markers to avoid ordinal integers (typically ID variables)

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/StandaloneMapMarkersPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/StandaloneMapMarkersPlugin.java
@@ -50,7 +50,6 @@ public class StandaloneMapMarkersPlugin extends AbstractEmptyComputePlugin<Stand
         .element("overlayVariable")
           .shapes(APIVariableDataShape.ORDINAL)
           .types(APIVariableType.STRING)
-      .done()
       .pattern()
         .element("geoAggregateVariable")
           .types(APIVariableType.STRING)

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/StandaloneMapMarkersPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/StandaloneMapMarkersPlugin.java
@@ -48,6 +48,18 @@ public class StandaloneMapMarkersPlugin extends AbstractEmptyComputePlugin<Stand
         .element("longitudeVariable")
           .types(APIVariableType.LONGITUDE)
         .element("overlayVariable")
+          .shapes(APIVariableDataShape.ORDINAL)
+          .types(APIVariableType.STRING)
+      .done()
+      .pattern()
+        .element("geoAggregateVariable")
+          .types(APIVariableType.STRING)
+        .element("latitudeVariable")
+          .types(APIVariableType.NUMBER)
+        .element("longitudeVariable")
+          .types(APIVariableType.LONGITUDE)
+        .element("overlayVariable")
+          .shapes(APIVariableDataShape.CONTINUOUS, APIVariableDataShape.CATEGORICAL, APIVariableDataShape.BINARY)
       .done();
   }
 


### PR DESCRIPTION
Fixes #29 

We know that type=string shape=ordinal variables work in map markers (because they have a vocabulary) so we allow only this kind of ordinal variable. The other shapes are allowed without further type constraints as before.

