### PR TITLE
Fix collection markers plugin by request geo vars

### DIFF
--- a/schema/library.raml
+++ b/schema/library.raml
@@ -2454,7 +2454,7 @@ types:
       viewport:
         description: Viewport used to filter markers. Only entities that are contained in the viewport will be grouped into markers.
         type: GeolocationViewport
-      collection:
+      collectionOverlay:
         description: Collection variable to use for markers.
         type: CollectionOverlayConfig
       aggregatorConfig:
@@ -2464,7 +2464,7 @@ types:
     type: object
     properties:
       collection: CollectionSpec
-      selectedMembers: VariableSpec[]
+      selectedMembers: string[]
   CollectionMapMarkerElement:
     description: |
       Data needed to render a collection map marker. Contains geographical data as well as per-variable collection var

--- a/schema/url/data/standalone-map/plugin-collection-markers.raml
+++ b/schema/url/data/standalone-map/plugin-collection-markers.raml
@@ -9,7 +9,7 @@ types:
 
   StandaloneCollectionMapMarkerSpec:
     additionalProperties: false
-    description: Specification for a map marker
+    description: Specification for a collection-level map marker visualization.
     properties:
       outputEntityId:
         required: true
@@ -27,7 +27,7 @@ types:
       viewport:
         type: GeolocationViewport
         description: Viewport used to filter markers. Only entities that are contained in the viewport will be grouped into markers.
-      collection:
+      collectionOverlay:
         required: true
         type: CollectionOverlayConfig
         description: Collection variable to use for markers.
@@ -37,9 +37,11 @@ types:
         description: Specification for how variable values will be aggregated into quantiative value shown in bar plot marker.
 
   CollectionOverlayConfig:
+    description: | 
+      Overlay configuration for the collection. Note that the variable IDs indicated must be members of the collection.
     properties:
       collection: CollectionSpec
-      selectedMembers: VariableSpec[]
+      selectedMembers: string[]
 
   CollectionMapMarkerElement:
     description: |

--- a/src/main/java/org/veupathdb/service/eda/common/plugin/util/PluginUtil.java
+++ b/src/main/java/org/veupathdb/service/eda/common/plugin/util/PluginUtil.java
@@ -13,6 +13,7 @@ import org.veupathdb.service.eda.generated.model.CollectionSpec;
 import org.veupathdb.service.eda.generated.model.DynamicDataSpec;
 import org.veupathdb.service.eda.generated.model.LabeledRange;
 import org.veupathdb.service.eda.generated.model.VariableSpec;
+import org.veupathdb.service.eda.generated.model.VariableSpecImpl;
 
 import java.lang.StringBuilder;
 import java.util.ArrayList;
@@ -145,6 +146,16 @@ public class PluginUtil {
   public List<String> getCollectionVocabulary(CollectionSpec collection) {
     return collection == null ? null : _metadata.getCollection(collection).orElseThrow().getVocabulary();
 
+  }
+
+  public static List<VariableSpec> variablesFromCollectionMembers(CollectionSpec collection, List<String> memberIds) {
+    return memberIds.stream()
+        .map(memberVarId -> {
+          VariableSpec varSpec = new VariableSpecImpl();
+          varSpec.setEntityId(collection.getEntityId());
+          varSpec.setVariableId(memberVarId);
+          return varSpec;
+        }).toList();
   }
 
   //deprecated

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/CollectionFloatingBarplotPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/CollectionFloatingBarplotPlugin.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.veupathdb.service.eda.common.plugin.util.PluginUtil.variablesFromCollectionMembers;
 import static org.veupathdb.service.eda.common.plugin.util.RServeClient.streamResult;
 import static org.veupathdb.service.eda.common.plugin.util.RServeClient.useRConnectionWithRemoteFiles;
 import static org.veupathdb.service.eda.data.metadata.AppsMetadata.VECTORBASE_PROJECT;
@@ -58,9 +59,12 @@ public class CollectionFloatingBarplotPlugin extends AbstractEmptyComputePlugin<
 
   @Override
   protected void validateVisualizationSpec(CollectionFloatingBarplotSpec pluginSpec) throws ValidationException {
-    ValidationUtils.validateCollectionMembers(getUtil(),
+    List<VariableSpec> collectionMembers = variablesFromCollectionMembers(
         pluginSpec.getOverlayConfig().getCollection(),
         pluginSpec.getOverlayConfig().getSelectedMembers());
+    ValidationUtils.validateCollectionMembers(getUtil(),
+        pluginSpec.getOverlayConfig().getCollection(),
+        collectionMembers);
     if (pluginSpec.getBarMode() == null) {
       throw new ValidationException("Property 'barMode' is required.");
     }
@@ -68,9 +72,12 @@ public class CollectionFloatingBarplotPlugin extends AbstractEmptyComputePlugin<
 
   @Override
   protected List<StreamSpec> getRequestedStreams(CollectionFloatingBarplotSpec pluginSpec) {
+    List<VariableSpec> collectionMembers = variablesFromCollectionMembers(
+        pluginSpec.getOverlayConfig().getCollection(),
+        pluginSpec.getOverlayConfig().getSelectedMembers());
     String outputEntityId = pluginSpec.getOutputEntityId();
     List<VariableSpec> plotVariableSpecs = new ArrayList<VariableSpec>();
-    plotVariableSpecs.addAll(pluginSpec.getOverlayConfig().getSelectedMembers());
+    plotVariableSpecs.addAll(collectionMembers);
 
     List<VariableSpec> varSpecsForMainRequest = getVarSpecsForStandaloneMapMainStream(outputEntityId, plotVariableSpecs);
 

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/CollectionFloatingBoxplotPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/CollectionFloatingBoxplotPlugin.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.veupathdb.service.eda.common.plugin.util.PluginUtil.variablesFromCollectionMembers;
 import static org.veupathdb.service.eda.common.plugin.util.RServeClient.streamResult;
 import static org.veupathdb.service.eda.common.plugin.util.RServeClient.useRConnectionWithProcessedRemoteFiles;
 import static org.veupathdb.service.eda.data.metadata.AppsMetadata.VECTORBASE_PROJECT;
@@ -63,20 +64,26 @@ public class CollectionFloatingBoxplotPlugin extends AbstractEmptyComputePlugin<
 
   @Override
   protected void validateVisualizationSpec(CollectionFloatingBoxplotSpec pluginSpec) throws ValidationException {
+    List<VariableSpec> collectionMembers = variablesFromCollectionMembers(
+        pluginSpec.getOverlayConfig().getCollection(),
+        pluginSpec.getOverlayConfig().getSelectedMembers());
     validateInputs(new DataElementSet()
       .entity(pluginSpec.getOutputEntityId())
       .var("xAxisVariable", pluginSpec.getXAxisVariable()));
     ValidationUtils.validateCollectionMembers(getUtil(),
         pluginSpec.getOverlayConfig().getCollection(),
-        pluginSpec.getOverlayConfig().getSelectedMembers());
+        collectionMembers);
   }
 
   @Override
   protected List<StreamSpec> getRequestedStreams(CollectionFloatingBoxplotSpec pluginSpec) {
+    List<VariableSpec> collectionMembers = variablesFromCollectionMembers(
+        pluginSpec.getOverlayConfig().getCollection(),
+        pluginSpec.getOverlayConfig().getSelectedMembers());
     String outputEntityId = pluginSpec.getOutputEntityId();
     List<VariableSpec> plotVariableSpecs = new ArrayList<VariableSpec>();
     plotVariableSpecs.add(pluginSpec.getXAxisVariable());
-    plotVariableSpecs.addAll(pluginSpec.getOverlayConfig().getSelectedMembers());
+    plotVariableSpecs.addAll(collectionMembers);
 
     List<VariableSpec> varSpecsForMainRequest = getVarSpecsForStandaloneMapMainStream(outputEntityId, plotVariableSpecs);
 
@@ -93,7 +100,10 @@ public class CollectionFloatingBoxplotPlugin extends AbstractEmptyComputePlugin<
     PluginUtil util = getUtil();
     CollectionFloatingBoxplotSpec spec = getPluginSpec();
     String outputEntityId = spec.getOutputEntityId();
-    List<VariableSpec> inputVarSpecs = new ArrayList<>(spec.getOverlayConfig().getSelectedMembers());
+    List<VariableSpec> inputVarSpecs = variablesFromCollectionMembers(
+        spec.getOverlayConfig().getCollection(),
+        spec.getOverlayConfig().getSelectedMembers());
+
     inputVarSpecs.add(spec.getXAxisVariable());
     CollectionSpec overlayVariable = spec.getOverlayConfig().getCollection();
     Map<String, DynamicDataSpec> varMap = new HashMap<>();

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/CollectionFloatingContTablePlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/CollectionFloatingContTablePlugin.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.veupathdb.service.eda.common.plugin.util.PluginUtil.variablesFromCollectionMembers;
 import static org.veupathdb.service.eda.common.plugin.util.RServeClient.streamResult;
 import static org.veupathdb.service.eda.common.plugin.util.RServeClient.useRConnectionWithRemoteFiles;
 import static org.veupathdb.service.eda.data.metadata.AppsMetadata.VECTORBASE_PROJECT;
@@ -54,14 +55,16 @@ public class CollectionFloatingContTablePlugin extends AbstractEmptyComputePlugi
   protected void validateVisualizationSpec(CollectionFloatingContTableSpec pluginSpec) throws ValidationException {
     ValidationUtils.validateCollectionMembers(getUtil(),
         pluginSpec.getXAxisVariable().getCollection(),
-        pluginSpec.getXAxisVariable().getSelectedMembers());
+        variablesFromCollectionMembers(pluginSpec.getXAxisVariable().getCollection(), pluginSpec.getXAxisVariable().getSelectedMembers()));
   }
 
   @Override
   protected List<StreamSpec> getRequestedStreams(CollectionFloatingContTableSpec pluginSpec) {   
     String outputEntityId = pluginSpec.getOutputEntityId();
-    List<VariableSpec> plotVariableSpecs = new ArrayList<VariableSpec>();
-    plotVariableSpecs.addAll(pluginSpec.getXAxisVariable().getSelectedMembers());
+    List<VariableSpec> plotVariableSpecs = new ArrayList<>(
+        variablesFromCollectionMembers(
+            pluginSpec.getXAxisVariable().getCollection(),
+            pluginSpec.getXAxisVariable().getSelectedMembers()));
 
     List<VariableSpec> varSpecsForMainRequest = getVarSpecsForStandaloneMapMainStream(outputEntityId, plotVariableSpecs);
 

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/CollectionFloatingHistogramPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/CollectionFloatingHistogramPlugin.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.veupathdb.service.eda.common.plugin.util.PluginUtil.variablesFromCollectionMembers;
 import static org.veupathdb.service.eda.common.plugin.util.RServeClient.streamResult;
 import static org.veupathdb.service.eda.common.plugin.util.RServeClient.useRConnectionWithRemoteFiles;
 import static org.veupathdb.service.eda.data.metadata.AppsMetadata.VECTORBASE_PROJECT;
@@ -58,9 +59,12 @@ public class CollectionFloatingHistogramPlugin extends AbstractEmptyComputePlugi
 
   @Override
   protected void validateVisualizationSpec(CollectionFloatingHistogramSpec pluginSpec) throws ValidationException {
-    ValidationUtils.validateCollectionMembers(getUtil(),
+    List<VariableSpec> collectionMembers = variablesFromCollectionMembers(
         pluginSpec.getOverlayConfig().getCollection(),
         pluginSpec.getOverlayConfig().getSelectedMembers());
+    ValidationUtils.validateCollectionMembers(getUtil(),
+        pluginSpec.getOverlayConfig().getCollection(),
+        collectionMembers);
     if (pluginSpec.getBarMode() == null) {
       throw new ValidationException("Property 'barMode' is required.");
     }
@@ -68,9 +72,12 @@ public class CollectionFloatingHistogramPlugin extends AbstractEmptyComputePlugi
 
   @Override
   protected List<StreamSpec> getRequestedStreams(CollectionFloatingHistogramSpec pluginSpec) {
+    List<VariableSpec> collectionMembers = variablesFromCollectionMembers(
+        pluginSpec.getOverlayConfig().getCollection(),
+        pluginSpec.getOverlayConfig().getSelectedMembers());
     String outputEntityId = pluginSpec.getOutputEntityId();
     List<VariableSpec> plotVariableSpecs = new ArrayList<VariableSpec>();
-    plotVariableSpecs.addAll(pluginSpec.getOverlayConfig().getSelectedMembers());
+    plotVariableSpecs.addAll(collectionMembers);
 
     List<VariableSpec> varSpecsForMainRequest = getVarSpecsForStandaloneMapMainStream(outputEntityId, plotVariableSpecs);
 

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/CollectionFloatingLineplotPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/CollectionFloatingLineplotPlugin.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.veupathdb.service.eda.common.plugin.util.PluginUtil.singleQuote;
+import static org.veupathdb.service.eda.common.plugin.util.PluginUtil.variablesFromCollectionMembers;
 import static org.veupathdb.service.eda.common.plugin.util.RServeClient.streamResult;
 import static org.veupathdb.service.eda.common.plugin.util.RServeClient.useRConnectionWithRemoteFiles;
 import static org.veupathdb.service.eda.data.metadata.AppsMetadata.VECTORBASE_PROJECT;
@@ -59,20 +60,26 @@ public class CollectionFloatingLineplotPlugin extends AbstractEmptyComputePlugin
 
   @Override
   protected void validateVisualizationSpec(CollectionFloatingLineplotSpec pluginSpec) throws ValidationException {
+    List<VariableSpec> collectionMembers = variablesFromCollectionMembers(
+        pluginSpec.getOverlayConfig().getCollection(),
+        pluginSpec.getOverlayConfig().getSelectedMembers());
     validateInputs(new DataElementSet()
       .entity(pluginSpec.getOutputEntityId())
       .var("xAxisVariable", pluginSpec.getXAxisVariable()));
     ValidationUtils.validateCollectionMembers(getUtil(),
         pluginSpec.getOverlayConfig().getCollection(),
-        pluginSpec.getOverlayConfig().getSelectedMembers());
+        collectionMembers);
   }
 
   @Override
   protected List<StreamSpec> getRequestedStreams(CollectionFloatingLineplotSpec pluginSpec) {
+    List<VariableSpec> collectionMembers = variablesFromCollectionMembers(
+        pluginSpec.getOverlayConfig().getCollection(),
+        pluginSpec.getOverlayConfig().getSelectedMembers());
     String outputEntityId = pluginSpec.getOutputEntityId();
     List<VariableSpec> plotVariableSpecs = new ArrayList<VariableSpec>();
     plotVariableSpecs.add(pluginSpec.getXAxisVariable());
-    plotVariableSpecs.addAll(pluginSpec.getOverlayConfig().getSelectedMembers());
+    plotVariableSpecs.addAll(collectionMembers);
 
     List<VariableSpec> varSpecsForMainRequest = getVarSpecsForStandaloneMapMainStream(outputEntityId, plotVariableSpecs);
 
@@ -89,7 +96,9 @@ public class CollectionFloatingLineplotPlugin extends AbstractEmptyComputePlugin
     PluginUtil util = getUtil();
     CollectionFloatingLineplotSpec spec = getPluginSpec();
     String outputEntityId = spec.getOutputEntityId();
-    List<VariableSpec> inputVarSpecs = new ArrayList<>(spec.getOverlayConfig().getSelectedMembers());
+    List<VariableSpec> inputVarSpecs = variablesFromCollectionMembers(
+        spec.getOverlayConfig().getCollection(),
+        spec.getOverlayConfig().getSelectedMembers());
     inputVarSpecs.add(spec.getXAxisVariable());
     CollectionSpec overlayVariable = spec.getOverlayConfig().getCollection();
     Map<String, DynamicDataSpec> varMap = new HashMap<>();


### PR DESCRIPTION
## Overview
1. Updated collections API to disallow clients to incorrectly select members that are not a part of the collection
2. Fixed a bug where the collections map marker plugin wasn't requesting geographic vars from merging stream