### PR TITLE
first child value derived variable

### DIFF
--- a/schema/library.raml
+++ b/schema/library.raml
@@ -3038,6 +3038,7 @@ types:
       subsetMembership: SubsetMembershipConfig
       advancedSubset: AdvancedSubsetConfig
       unitConversion: UnitConversionConfig
+      firstChildValue: FirstChildValueConfig
       bodyMassIndex: BodyMassIndexConfig
       categoricalRecoding: CategoricalRecodingConfig
       continuousToOrdinal: ContinuousNumericRecodingConfig
@@ -3106,6 +3107,10 @@ types:
     properties:
       inputVariable: VariableSpec
       outputUnits: string
+  FirstChildValueConfig:
+    type: object
+    properties:
+      inputVariable: VariableSpec
   SetOperation:
     type: string
     enum:

--- a/schema/url/merge/derived-variable-metadata.raml
+++ b/schema/url/merge/derived-variable-metadata.raml
@@ -10,6 +10,7 @@ types:
       subsetMembership: SubsetMembershipConfig
       advancedSubset: AdvancedSubsetConfig
       unitConversion: UnitConversionConfig
+      firstChildValue: FirstChildValueConfig
       bodyMassIndex: BodyMassIndexConfig
       categoricalRecoding: CategoricalRecodingConfig
       continuousToOrdinal: ContinuousNumericRecodingConfig

--- a/schema/url/merge/derived-variables.raml
+++ b/schema/url/merge/derived-variables.raml
@@ -51,6 +51,10 @@ types:
       inputVariable: VariableSpec
       outputUnits: string
 
+  FirstChildValueConfig:
+    properties:
+      inputVariable: VariableSpec
+
   SetOperation:
     type: string
     enum: [ 'intersect', 'union', 'minus' ]

--- a/src/main/java/org/veupathdb/service/eda/merge/plugins/Reductions.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/plugins/Reductions.java
@@ -2,10 +2,7 @@ package org.veupathdb.service.eda.merge.plugins;
 
 import org.veupathdb.service.eda.merge.core.derivedvars.DerivedVariableFactory;
 import org.veupathdb.service.eda.merge.core.derivedvars.Reduction;
-import org.veupathdb.service.eda.merge.plugins.reductions.Mean;
-import org.veupathdb.service.eda.merge.plugins.reductions.RelativeObservationAggregator;
-import org.veupathdb.service.eda.merge.plugins.reductions.SubsetMembership;
-import org.veupathdb.service.eda.merge.plugins.reductions.Sum;
+import org.veupathdb.service.eda.merge.plugins.reductions.*;
 
 import static org.veupathdb.service.eda.merge.core.derivedvars.DerivedVariableFactory.pluginsOf;
 
@@ -19,7 +16,8 @@ public class Reductions {
         Sum.class,
         Mean.class,
         SubsetMembership.class,
-        RelativeObservationAggregator.class
+        RelativeObservationAggregator.class,
+        FirstChildValue.class
     );
   }
 }

--- a/src/main/java/org/veupathdb/service/eda/merge/plugins/reductions/FirstChildValue.java
+++ b/src/main/java/org/veupathdb/service/eda/merge/plugins/reductions/FirstChildValue.java
@@ -1,0 +1,76 @@
+package org.veupathdb.service.eda.merge.plugins.reductions;
+
+import org.gusdb.fgputil.validation.ValidationException;
+import org.veupathdb.service.eda.common.model.VariableDef;
+import org.veupathdb.service.eda.generated.model.APIVariableDataShape;
+import org.veupathdb.service.eda.generated.model.APIVariableType;
+import org.veupathdb.service.eda.generated.model.FirstChildValueConfig;
+import org.veupathdb.service.eda.generated.model.VariableSpec;
+import org.veupathdb.service.eda.merge.core.derivedvars.Reduction;
+
+import java.util.List;
+import java.util.Map;
+
+public class FirstChildValue extends Reduction<FirstChildValueConfig> {
+
+  private VariableSpec _childVariable;
+  private String _childVariableColumnName;
+  private VariableDef _childVariableDef;
+
+  @Override
+  public String getFunctionName() {
+    return "firstChildValue";
+  }
+
+  @Override
+  protected Class<FirstChildValueConfig> getConfigClass() {
+    return FirstChildValueConfig.class;
+  }
+
+  @Override
+  protected void acceptConfig(FirstChildValueConfig config) throws ValidationException {
+    _childVariable = config.getInputVariable();
+    _childVariableColumnName = VariableDef.toDotNotation(_childVariable);
+  }
+
+  @Override
+  protected void performSupplementalDependedVariableValidation() throws ValidationException {
+    // metadata populated now; get def to return type and shape
+    _childVariableDef = _metadata.getVariable(_childVariable).get(); // already validated
+  }
+
+  @Override
+  public List<VariableSpec> getRequiredInputVars() {
+    return List.of(_childVariable);
+  }
+
+  @Override
+  public APIVariableType getVariableType() {
+    return _childVariableDef.getType();
+  }
+
+  @Override
+  public APIVariableDataShape getDataShape() {
+    return _childVariableDef.getDataShape();
+  }
+
+  @Override
+  public Reducer createReducer() {
+    return new Reducer() {
+
+      private String _firstValue;
+
+      @Override
+      public void addRow(Map<String, String> nextRow) {
+        // only set the first value returned
+        if (_firstValue == null)
+          _firstValue = nextRow.get(_childVariableColumnName);
+      }
+
+      @Override
+      public String getResultingValue() {
+        return _firstValue == null ? "" : _firstValue;
+      }
+    };
+  }
+}


### PR DESCRIPTION
This enables a parent entity to pull a child's variable value up into itself.  Since parent:child relationships can be 1:many, we only pull the first child row's value for each parent ID, ensuring a single value gets pulled.  This is to field a request from @d-callan that a parent entity pull values from multiple child entities which are all 1:1 record relationship between each other.