### PR TITLE
Fix marker consistency and exclude empty collection markers

### DIFF
--- a/schema/library.raml
+++ b/schema/library.raml
@@ -2338,6 +2338,18 @@ types:
     type: DataPluginRequestBase
     properties:
       config: CollectionSpec
+  BaseMarker:
+    type: object
+    additionalProperties: false
+    properties:
+      geoAggregateValue: string
+      entityCount: number
+      avgLat: number
+      avgLon: number
+      minLat: number
+      minLon: number
+      maxLat: number
+      maxLon: number
   CollectionFloatingBarplotPostRequest:
     type: DataPluginRequestBase
     properties:
@@ -2435,7 +2447,7 @@ types:
     properties:
       config: StandaloneCollectionMapMarkerSpec
   StandaloneCollectionMapMarkerSpec:
-    description: Specification for a map marker
+    description: Specification for a collection-level map marker visualization.
     type: object
     additionalProperties: false
     properties:
@@ -2461,6 +2473,8 @@ types:
         description: Specification for how variable values will be aggregated into quantiative value shown in bar plot marker.
         type: QuantitativeAggregationConfig
   CollectionOverlayConfig:
+    description: |
+      Overlay configuration for the collection. Note that the variable IDs indicated must be members of the collection.
     type: object
     properties:
       collection: CollectionSpec
@@ -2469,16 +2483,9 @@ types:
     description: |
       Data needed to render a collection map marker. Contains geographical data as well as per-variable collection var
       aggregates needed to render bar plots with error bar.
-    type: object
+    type: BaseMarker
     properties:
-      entityCount: number
-      avgLat: number
-      avgLon: number
-      minLat: number
-      minLon: number
-      maxLat: number
-      maxLon: number
-      values: CollectionMemberAggregate[]
+      overlayValues: CollectionMemberAggregate[]
   CollectionMemberAggregate:
     type: object
     properties:
@@ -2681,6 +2688,7 @@ types:
       scatterplot: FloatingScatterplot
   StandaloneMapBubblesLegendPostRequest:
     type: DataPluginRequestBase
+    additionalProperties: false
     properties:
       config: StandaloneMapBubblesLegendSpec
   StandaloneMapBubblesLegendSpec:
@@ -2743,18 +2751,10 @@ types:
     properties:
       mapElements: ColoredMapElementInfo[]
   ColoredMapElementInfo:
-    type: object
+    type: BaseMarker
     additionalProperties: false
     properties:
-      geoAggregateValue: string
-      entityCount: number
       overlayValue: string
-      avgLat: number
-      avgLon: number
-      minLat: number
-      minLon: number
-      maxLat: number
-      maxLon: number
   StandaloneMapMarkersPostRequest:
     type: DataPluginRequestBase
     properties:
@@ -2802,18 +2802,11 @@ types:
       overlayValues:
         type: string[]
   StandaloneMapElementInfo:
-    type: object
+    type: BaseMarker
     additionalProperties: false
     properties:
-      geoAggregateValue: string
-      entityCount: number
-      overlayValues: LegacyLabeledRangeWithCountAndValue[]
-      avgLat: number
-      avgLon: number
-      minLat: number
-      minLon: number
-      maxLat: number
-      maxLon: number
+      overlayValues:
+        type: LegacyLabeledRangeWithCountAndValue[]
   DataPluginRequestBase:
     type: object
     additionalProperties: false

--- a/schema/url/data/standalone-map/markers-common.raml
+++ b/schema/url/data/standalone-map/markers-common.raml
@@ -1,0 +1,15 @@
+#%RAML 1.0 Library
+
+types:
+  BaseMarker:
+    additionalProperties: false
+    type: object
+    properties:
+      geoAggregateValue: string
+      entityCount: number
+      avgLat: number
+      avgLon: number
+      minLat: number
+      minLon: number
+      maxLat: number
+      maxLon: number

--- a/schema/url/data/standalone-map/plugin-collection-markers.raml
+++ b/schema/url/data/standalone-map/plugin-collection-markers.raml
@@ -44,18 +44,12 @@ types:
       selectedMembers: string[]
 
   CollectionMapMarkerElement:
+    type: BaseMarker
     description: |
       Data needed to render a collection map marker. Contains geographical data as well as per-variable collection var
       aggregates needed to render bar plots with error bar.
     properties:
-      entityCount: number
-      avgLat: number
-      avgLon: number
-      minLat: number
-      minLon: number
-      maxLat: number
-      maxLon: number
-      values: CollectionMemberAggregate[]
+      overlayValues: CollectionMemberAggregate[]
 
   CollectionMemberAggregate:
     properties:

--- a/schema/url/data/standalone-map/plugin-map-bubbles.raml
+++ b/schema/url/data/standalone-map/plugin-map-bubbles.raml
@@ -3,6 +3,7 @@
 types:
 
   StandaloneMapBubblesLegendPostRequest:
+    additionalProperties: false
     type: DataPluginRequestBase
     properties:
       config: StandaloneMapBubblesLegendSpec
@@ -75,23 +76,7 @@ types:
       mapElements: ColoredMapElementInfo[]
 
   ColoredMapElementInfo:
+    type: BaseMarker
     additionalProperties: false
     properties:
-      geoAggregateValue:
-        type: string
-      entityCount:
-        type: number
-      overlayValue:
-        type: string
-      avgLat:
-        type: number
-      avgLon:
-        type: number
-      minLat:
-        type: number
-      minLon:
-        type: number
-      maxLat:
-        type: number
-      maxLon:
-        type: number
+      overlayValue: string

--- a/schema/url/data/standalone-map/plugin-standalone-map-markers.raml
+++ b/schema/url/data/standalone-map/plugin-standalone-map-markers.raml
@@ -61,23 +61,8 @@ types:
         type: string[]
 
   StandaloneMapElementInfo:
+    type: BaseMarker
     additionalProperties: false
     properties:
-      geoAggregateValue:
-        type: string
-      entityCount:
-        type: number
       overlayValues:
         type: LegacyLabeledRangeWithCountAndValue[]
-      avgLat:
-        type: number
-      avgLon:
-        type: number
-      minLat:
-        type: number
-      minLon:
-        type: number
-      maxLat:
-        type: number
-      maxLon:
-        type: number

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/StandaloneMapMarkersPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/StandaloneMapMarkersPlugin.java
@@ -19,6 +19,7 @@ import org.veupathdb.service.eda.common.plugin.constraint.DataElementSet;
 import org.veupathdb.service.eda.data.core.AbstractEmptyComputePlugin;
 import org.veupathdb.service.eda.data.plugin.standalonemap.aggregator.MarkerAggregator;
 import org.veupathdb.service.eda.data.plugin.standalonemap.aggregator.QualitativeOverlayAggregator;
+import org.veupathdb.service.eda.data.plugin.standalonemap.conversion.ApiConverter;
 import org.veupathdb.service.eda.data.plugin.standalonemap.markers.MapMarkerRowProcessor;
 import org.veupathdb.service.eda.data.plugin.standalonemap.markers.MarkerData;
 import org.veupathdb.service.eda.data.plugin.standalonemap.markers.OverlaySpecification;
@@ -135,15 +136,7 @@ public class StandaloneMapMarkersPlugin extends AbstractEmptyComputePlugin<Stand
     for (String key : aggregator.keySet()) {
       StandaloneMapElementInfo mapEle = new StandaloneMapElementInfoImpl();
       MarkerData<Map<String, QualitativeOverlayAggregator.CategoricalOverlayData>> data = aggregator.get(key);
-      GeographicPoint avgLatLon = data.getLatLonAvg().getCurrentAverage();
-      mapEle.setGeoAggregateValue(key);
-      mapEle.setEntityCount(data.getCount());
-      mapEle.setAvgLat(avgLatLon.getLatitude());
-      mapEle.setAvgLon(avgLatLon.getLongitude());
-      mapEle.setMinLat(data.getMinLat());
-      mapEle.setMaxLat(data.getMaxLat());
-      mapEle.setMinLon(data.getMinLon());
-      mapEle.setMaxLon(data.getMaxLon());
+      ApiConverter.populateBaseMarkerData(key, mapEle, data);
       if (data.getMarkerAggregator() != null) {
         mapEle.setOverlayValues(convertAggregator(data.getMarkerAggregator(), valueSpec));
       }

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/conversion/ApiConverter.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/standalonemap/conversion/ApiConverter.java
@@ -1,0 +1,19 @@
+package org.veupathdb.service.eda.data.plugin.standalonemap.conversion;
+
+import org.veupathdb.service.eda.data.plugin.standalonemap.markers.MarkerData;
+import org.veupathdb.service.eda.generated.model.BaseMarker;
+
+public class ApiConverter {
+
+  public static void populateBaseMarkerData(String geoAggValue, BaseMarker baseMarker, MarkerData<?> markerData) {
+    baseMarker.setAvgLat(markerData.getLatLonAvg().getCurrentAverage().getLatitude());
+    baseMarker.setAvgLon(markerData.getLatLonAvg().getCurrentAverage().getLongitude());
+    baseMarker.setMaxLat(markerData.getMaxLat());
+    baseMarker.setMaxLon(markerData.getMaxLon());
+    baseMarker.setMinLat(markerData.getMinLat());
+    baseMarker.setMinLon(markerData.getMinLon());
+    baseMarker.setEntityCount(markerData.getCount());
+    baseMarker.setGeoAggregateValue(geoAggValue);
+  }
+
+}


### PR DESCRIPTION
## Overview
* Marker responses now share a common base
* Overlay values field renamed in collections for consistency
* Filtering out empty collection markers