### PR TITLE
add differential expression

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -454,6 +454,29 @@ securitySchemes:
             body:
               application/json: lib.DifferentialAbundanceStatsResponse
 
+  /differentialexpression:
+    post:
+      queryParameters:
+        autostart:
+          type: boolean
+          required: false
+          default: true
+      body:
+        application/json: lib.DifferentialExpressionPluginRequest
+      responses:
+        200:
+          body:
+            application/json: lib.JobResponse
+    /statistics:
+      post:
+        body:
+          application/json: lib.DifferentialExpressionPluginRequest
+        responses:
+          200:
+            body:
+              application/json: lib.DifferentialExpressionStatsResponse
+
+
   /correlation:
     post:
       queryParameters:

--- a/api.raml
+++ b/api.raml
@@ -1299,6 +1299,21 @@ securitySchemes:
               application/json:
                 type: lib.DifferentialAbundanceStatsResponse
 
+  /differentialexpression/visualizations:
+    displayName: Visualizations for interrogating differentially expressed genes
+
+    /volcanoplot:
+      post:
+        description: Returns data required to create a volcanoplot from a differential expression analysis.
+        body:
+          application/json:
+            type: lib.DifferentialExpressionVolcanoplotPostRequest
+        responses:
+          200:
+            body:
+              application/json:
+                type: lib.DifferentialExpressionStatsResponse
+
   /correlation/visualizations:
     displayName: Visualizations for discovering correlations between various assay data
 

--- a/schema/library.raml
+++ b/schema/library.raml
@@ -1194,8 +1194,6 @@ types:
     type: string
     enum:
       - DESeq
-      - ANCOMBC
-      - Maaslin
   ComparatorSpec:
     type: object
     properties:

--- a/schema/library.raml
+++ b/schema/library.raml
@@ -1148,7 +1148,7 @@ types:
     type: object
     properties:
       collectionVariable: CollectionSpec
-      comparator: ComparatorSpec
+      comparator: DifferentialAbundanceComparatorSpec
       differentialAbundanceMethod: DifferentialAbundanceMethod
       pValueFloor:
         type: string
@@ -1159,7 +1159,7 @@ types:
       - DESeq
       - ANCOMBC
       - Maaslin
-  ComparatorSpec:
+  DifferentialAbundanceComparatorSpec:
     type: object
     properties:
       variable: VariableSpec
@@ -1177,6 +1177,43 @@ types:
     properties:
       effectSizeLabel: string
       statistics: DifferentialAbundanceStats
+  DifferentialExpressionPluginRequest:
+    type: ComputeRequestBase
+    properties:
+      config: DifferentialExpressionComputeConfig
+  DifferentialExpressionComputeConfig:
+    type: object
+    properties:
+      collectionVariable: CollectionSpec
+      comparator: ComparatorSpec
+      differentialExpressionMethod: DifferentialExpressionMethod
+      pValueFloor:
+        type: string
+        required: false
+  DifferentialExpressionMethod:
+    type: string
+    enum:
+      - DESeq
+      - ANCOMBC
+      - Maaslin
+  ComparatorSpec:
+    type: object
+    properties:
+      variable: VariableSpec
+      groupA: LabeledRange[]
+      groupB: LabeledRange[]
+  DifferentialExpressionPoint:
+    type: object
+    properties:
+      effectSize: string
+      pValue: string
+      adjustedPValue: string
+      pointId: string
+  DifferentialExpressionStatsResponse:
+    type: object
+    properties:
+      effectSizeLabel: string
+      statistics: DifferentialExpressionPoint[]
   ExamplePluginRequest:
     type: ComputeRequestBase
     properties:

--- a/schema/library.raml
+++ b/schema/library.raml
@@ -1418,6 +1418,11 @@ types:
     properties:
       computeConfig: DifferentialAbundanceComputeConfig
       config: EmptyDataPluginSpec
+  DifferentialExpressionVolcanoplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: DifferentialExpressionComputeConfig
+      config: EmptyDataPluginSpec
   ContinuousVariableMetadataPostRequest:
     type: DataPluginRequestBase
     additionalProperties: false

--- a/schema/url/compute/computes/differentialAbundance.raml
+++ b/schema/url/compute/computes/differentialAbundance.raml
@@ -10,7 +10,7 @@ types:
   DifferentialAbundanceComputeConfig:
     properties:
       collectionVariable: CollectionSpec
-      comparator: ComparatorSpec
+      comparator: DifferentialAbundanceComparatorSpec
       differentialAbundanceMethod: DifferentialAbundanceMethod
       pValueFloor:
         type: string
@@ -20,7 +20,7 @@ types:
     type: string
     enum: ['DESeq','ANCOMBC','Maaslin']
 
-  ComparatorSpec:
+  DifferentialAbundanceComparatorSpec:
     type: object
     properties:
       variable: VariableSpec

--- a/schema/url/compute/computes/differentialExpression.raml
+++ b/schema/url/compute/computes/differentialExpression.raml
@@ -18,7 +18,7 @@ types:
         
   DifferentialExpressionMethod:
     type: string
-    enum: ['DESeq','ANCOMBC','Maaslin']
+    enum: ['DESeq']
 
   ComparatorSpec:
     type: object

--- a/schema/url/compute/computes/differentialExpression.raml
+++ b/schema/url/compute/computes/differentialExpression.raml
@@ -1,0 +1,40 @@
+#%RAML 1.0 Library
+
+types:
+
+  DifferentialExpressionPluginRequest:
+    type: ComputeRequestBase
+    properties:
+      config: DifferentialExpressionComputeConfig
+
+  DifferentialExpressionComputeConfig:
+    properties:
+      collectionVariable: CollectionSpec
+      comparator: ComparatorSpec
+      differentialExpressionMethod: DifferentialExpressionMethod
+      pValueFloor:
+        type: string
+        required: false
+        
+  DifferentialExpressionMethod:
+    type: string
+    enum: ['DESeq','ANCOMBC','Maaslin']
+
+  ComparatorSpec:
+    type: object
+    properties:
+      variable: VariableSpec
+      groupA: LabeledRange[]
+      groupB: LabeledRange[]
+
+  DifferentialExpressionPoint:
+    properties:
+      effectSize: string
+      pValue: string
+      adjustedPValue: string
+      pointId: string
+
+  DifferentialExpressionStatsResponse:
+    properties:
+      effectSizeLabel: string
+      statistics: DifferentialExpressionPoint[]

--- a/schema/url/data/differentialexpression/plugin-differentialexpression-volcanoplot.raml
+++ b/schema/url/data/differentialexpression/plugin-differentialexpression-volcanoplot.raml
@@ -1,0 +1,9 @@
+#%RAML 1.0 Library
+
+types:
+
+  DifferentialExpressionVolcanoplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: DifferentialExpressionComputeConfig
+      config: EmptyDataPluginSpec

--- a/src/main/java/org/veupathdb/service/eda/compute/controller/ComputeController.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/controller/ComputeController.java
@@ -22,6 +22,7 @@ import org.veupathdb.service.eda.compute.plugins.alphadiv.AlphaDivPluginProvider
 import org.veupathdb.service.eda.compute.plugins.betadiv.BetaDivPluginProvider;
 import org.veupathdb.service.eda.compute.plugins.correlation.CorrelationPluginProvider;
 import org.veupathdb.service.eda.compute.plugins.differentialabundance.DifferentialAbundancePluginProvider;
+import org.veupathdb.service.eda.compute.plugins.differentialexpression.DifferentialExpressionPluginProvider;
 import org.veupathdb.service.eda.compute.plugins.example.ExamplePluginProvider;
 import org.veupathdb.service.eda.compute.plugins.rankedabundance.RankedAbundancePluginProvider;
 import org.veupathdb.service.eda.compute.plugins.selfcorrelation.SelfCorrelationPluginProvider;
@@ -126,6 +127,23 @@ public class ComputeController implements Computes {
     return PostComputesDifferentialabundanceStatisticsResponse.respond200WithApplicationJson(new DifferentialAbundanceStatsResponseStream(out -> {
       try {
         getResultFileStreamer(new DifferentialAbundancePluginProvider(), STATISTICS, entity).write(out);
+      }
+      catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }));
+  }
+
+  @Override
+  public PostComputesDifferentialexpressionResponse postComputesDifferentialexpression(Boolean autostart, DifferentialExpressionPluginRequest entity) {
+    return PostComputesDifferentialexpressionResponse.respond200WithApplicationJson(submitJob(new DifferentialExpressionPluginProvider(), entity, autostart));
+  }
+
+  @Override
+  public PostComputesDifferentialexpressionStatisticsResponse postComputesDifferentialexpressionStatistics(DifferentialExpressionPluginRequest entity) {
+    return PostComputesDifferentialexpressionStatisticsResponse.respond200WithApplicationJson(new DifferentialExpressionStatsResponseStream(out -> {
+      try {
+        getResultFileStreamer(new DifferentialExpressionPluginProvider(), STATISTICS, entity).write(out);
       }
       catch (IOException e) {
         throw new RuntimeException(e);

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/PluginRegistry.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/PluginRegistry.java
@@ -11,6 +11,7 @@ import org.veupathdb.service.eda.compute.plugins.selfcorrelation.SelfCorrelation
 import org.veupathdb.service.eda.compute.plugins.example.ExamplePluginProvider;
 import org.veupathdb.service.eda.compute.plugins.rankedabundance.RankedAbundancePluginProvider;
 import org.veupathdb.service.eda.compute.plugins.differentialabundance.DifferentialAbundancePluginProvider;
+import org.veupathdb.service.eda.compute.plugins.differentialexpression.DifferentialExpressionPluginProvider;
 import org.veupathdb.service.eda.generated.model.ComputeRequestBase;
 import org.veupathdb.service.eda.generated.model.PluginOverview;
 import org.veupathdb.service.eda.generated.model.PluginOverviewImpl;
@@ -50,6 +51,7 @@ public final class PluginRegistry {
       new BetaDivPluginProvider(),
       new RankedAbundancePluginProvider(),
       new DifferentialAbundancePluginProvider(),
+      new DifferentialExpressionPluginProvider(),
       new CorrelationPluginProvider(),
       new SelfCorrelationPluginProvider()
     );

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/differentialexpression/DifferentialExpressionPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/differentialexpression/DifferentialExpressionPlugin.java
@@ -1,0 +1,146 @@
+package org.veupathdb.service.eda.compute.plugins.differentialexpression;
+
+import org.gusdb.fgputil.ListBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.veupathdb.service.eda.common.client.spec.StreamSpec;
+import org.veupathdb.service.eda.common.model.CollectionDef;
+import org.veupathdb.service.eda.common.model.EntityDef;
+import org.veupathdb.service.eda.common.model.ReferenceMetadata;
+import org.veupathdb.service.eda.common.model.VariableDef;
+import org.veupathdb.service.eda.common.plugin.util.PluginUtil;
+import org.veupathdb.service.eda.compute.RServe;
+import org.veupathdb.service.eda.compute.plugins.AbstractPlugin;
+import org.veupathdb.service.eda.compute.plugins.PluginContext;
+import org.veupathdb.service.eda.generated.model.LabeledRange;
+import org.veupathdb.service.eda.generated.model.DifferentialExpressionComputeConfig;
+import org.veupathdb.service.eda.generated.model.DifferentialExpressionPluginRequest;
+import org.veupathdb.service.eda.generated.model.CollectionSpec;
+import org.veupathdb.service.eda.generated.model.VariableSpec;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.veupathdb.service.eda.common.plugin.util.PluginUtil.singleQuote;
+
+public class DifferentialExpressionPlugin extends AbstractPlugin<DifferentialExpressionPluginRequest, DifferentialExpressionComputeConfig> {
+
+  private static final String INPUT_DATA = "differential_expression_input";
+
+  public DifferentialExpressionPlugin(@NotNull PluginContext<DifferentialExpressionPluginRequest, DifferentialExpressionComputeConfig> context) {
+    super(context);
+  }
+
+  @NotNull
+  @Override
+  public List<StreamSpec> getStreamSpecs() {
+    return List.of(new StreamSpec(INPUT_DATA, getConfig().getCollectionVariable().getEntityId())
+        .addVars(getUtil().getCollectionMembers(getConfig().getCollectionVariable()))
+        .addVar(getConfig().getComparator().getVariable())
+      );
+  }
+
+  @Override
+  protected void execute() {
+
+    DifferentialExpressionComputeConfig computeConfig = getConfig();
+    PluginUtil util = getUtil();
+    ReferenceMetadata meta = getContext().getReferenceMetadata();
+
+    CollectionSpec collectionSpec = computeConfig.getCollectionVariable();
+    CollectionDef collection = meta.getCollection(collectionSpec).orElseThrow();
+    String collectionMemberType = collection.getMember() == null ? "unknown" : collection.getMember();
+    String entityId = collectionSpec.getEntityId();
+    EntityDef entity = meta.getEntity(entityId).orElseThrow();
+    VariableDef computeEntityIdVarSpec = util.getEntityIdVarSpec(entityId);
+    String computeEntityIdColName = util.toColNameOrEmpty(computeEntityIdVarSpec);
+    // if we ever introduce ANCOM-BC or something else we'll need to change this
+    String method = computeConfig.getDifferentialExpressionMethod().getValue().equals("Maaslin") ? "Maaslin2" : "DESeq2";
+    VariableSpec comparisonVariableSpec = computeConfig.getComparator().getVariable();
+    String comparisonVariableDataShape = util.getVariableDataShape(comparisonVariableSpec);
+    List<LabeledRange> groupA = computeConfig.getComparator().getGroupA();
+    List<LabeledRange> groupB =  computeConfig.getComparator().getGroupB();
+    String pValueFloor = computeConfig.getPValueFloor() != null ? computeConfig.getPValueFloor() : "1e-200"; // Same default as set in the frontend and microbiomeComputations
+
+    // Get record id columns
+    List<VariableDef> idColumns = new ArrayList<>();
+    for (EntityDef ancestor : meta.getAncestors(entity)) {
+      idColumns.add(ancestor.getIdColumnDef());
+    }
+
+    HashMap<String, InputStream> dataStream = new HashMap<>();
+    dataStream.put(INPUT_DATA, getWorkspace().openStream(INPUT_DATA));
+
+    RServe.useRConnectionWithRemoteFiles(dataStream, connection -> {
+      connection.voidEval("print('starting differential expression computation')");
+
+      // Read in the count data
+      List<VariableSpec> computeInputVars = ListBuilder.asList(computeEntityIdVarSpec);
+      computeInputVars.addAll(util.getCollectionMembers(collectionSpec));
+      computeInputVars.addAll(idColumns);
+      connection.voidEval(util.getVoidEvalFreadCommand(INPUT_DATA, computeInputVars));
+      connection.voidEval("countData <- " + INPUT_DATA); // Renaming here so we can go get the sampleMetadata later
+
+      // Read in the sample metadata
+      List<VariableSpec> sampleMetadataVars = ListBuilder.asList(comparisonVariableSpec);
+      sampleMetadataVars.add(computeEntityIdVarSpec);
+      connection.voidEval(util.getVoidEvalFreadCommand(INPUT_DATA, sampleMetadataVars));
+      connection.voidEval("sampleMetadata <- veupathUtils::SampleMetadata(data = " + INPUT_DATA
+                                + ", recordIdColumn = " + singleQuote(computeEntityIdColName)
+                                + ")");
+
+
+      // Turn the list of id columns into an array of strings for R
+      List<String> dotNotatedIdColumns = idColumns.stream().map(VariableDef::toDotNotation).toList();
+      StringBuilder dotNotatedIdColumnsString = new StringBuilder("c(");
+      boolean first = true;
+      for (String idCol : dotNotatedIdColumns) {
+        if (first) {
+          first = false;
+          dotNotatedIdColumnsString.append(singleQuote(idCol));
+        } else {
+          dotNotatedIdColumnsString.append(",").append(singleQuote(idCol));
+        }
+      }
+      dotNotatedIdColumnsString.append(")");
+
+      // Turn the comparator bin lists into a string for R
+      String rGroupA = util.getRBinListAsString(groupA);
+      String rGroupB = util.getRBinListAsString(groupB);
+
+
+      // Create the comparator and input data objects
+      connection.voidEval("comparator <- veupathUtils::Comparator(" +
+                                "variable=veupathUtils::VariableMetadata(" +
+                                  "variableSpec=veupathUtils::VariableSpec(" +
+                                    "variableId='" + comparisonVariableSpec.getVariableId() + "'," +
+                                    "entityId='" + comparisonVariableSpec.getEntityId() + "')," +
+                                  "dataShape = veupathUtils::DataShape(value = '" + comparisonVariableDataShape + "')" +
+                                ")," +
+                                "groupA=" + rGroupA + "," +
+                                "groupB=" + rGroupB +
+                              ")");
+
+      connection.voidEval("countDataCollection <- veupathUtils::CountDataCollection(name=" + singleQuote(collectionMemberType) +
+                                                                          ", data=countData" +
+                                                                          ", sampleMetadata=sampleMetadata" +
+                                                                          ", recordIdColumn=" + singleQuote(computeEntityIdColName) +
+                                                                          ", ancestorIdColumns=as.character(" + dotNotatedIdColumnsString + ")" +
+                                                                          ", imputeZero=TRUE)");
+
+      
+      connection.voidEval("computeResult <- veupathUtils::differentialExpression(" +
+                                                          "collection=countDataCollection" +
+                                                          ", comparator=comparator" +
+                                                          ", method=" + singleQuote(method) +
+                                                          ", pValueFloor=as.numeric(" + singleQuote(pValueFloor) + ")" +
+                                                          ", verbose=TRUE)");
+
+
+      String statsCmd = "writeStatistics(computeResult, NULL, TRUE)";
+
+      getWorkspace().writeStatisticsResult(connection, statsCmd);
+    });
+  }
+}

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/differentialexpression/DifferentialExpressionPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/differentialexpression/DifferentialExpressionPlugin.java
@@ -55,8 +55,8 @@ public class DifferentialExpressionPlugin extends AbstractPlugin<DifferentialExp
     EntityDef entity = meta.getEntity(entityId).orElseThrow();
     VariableDef computeEntityIdVarSpec = util.getEntityIdVarSpec(entityId);
     String computeEntityIdColName = util.toColNameOrEmpty(computeEntityIdVarSpec);
-    // if we ever introduce ANCOM-BC or something else we'll need to change this
-    String method = computeConfig.getDifferentialExpressionMethod().getValue().equals("Maaslin") ? "Maaslin2" : "DESeq2";
+    // if we ever introduce limma we can go back to this
+    String method = computeConfig.getDifferentialExpressionMethod().getValue().equals("DESeq") ? "DESeq" : "unknown";
     VariableSpec comparisonVariableSpec = computeConfig.getComparator().getVariable();
     String comparisonVariableDataShape = util.getVariableDataShape(comparisonVariableSpec);
     List<LabeledRange> groupA = computeConfig.getComparator().getGroupA();
@@ -121,6 +121,13 @@ public class DifferentialExpressionPlugin extends AbstractPlugin<DifferentialExp
                                 "groupA=" + rGroupA + "," +
                                 "groupB=" + rGroupB +
                               ")");
+
+      // TEMPORARY HACK FOR TESTING
+      // We dont have rnaseq data loaded yet (to my knowledge) so we are going to use mbio data and
+      // just convert it to counts. This is a hack and should be removed when we have real data
+      connection.voidEval("taxaColNames <- names(countData[, -c('" + computeEntityIdColName + "', as.character(" + dotNotatedIdColumnsString + "))])");
+      connection.voidEval("countData[, (taxaColNames) := lapply(.SD,function(x) {round(x*1000)}), .SDcols=taxaColNames]");
+      // END OF TEMP FOR TESTING
 
       connection.voidEval("countDataCollection <- veupathUtils::CountDataCollection(name=" + singleQuote(collectionMemberType) +
                                                                           ", data=countData" +

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/differentialexpression/DifferentialExpressionPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/differentialexpression/DifferentialExpressionPlugin.java
@@ -55,7 +55,6 @@ public class DifferentialExpressionPlugin extends AbstractPlugin<DifferentialExp
     EntityDef entity = meta.getEntity(entityId).orElseThrow();
     VariableDef computeEntityIdVarSpec = util.getEntityIdVarSpec(entityId);
     String computeEntityIdColName = util.toColNameOrEmpty(computeEntityIdVarSpec);
-    // if we ever introduce limma we can go back to this
     String method = computeConfig.getDifferentialExpressionMethod().getValue().equals("DESeq") ? "DESeq" : "unknown";
     VariableSpec comparisonVariableSpec = computeConfig.getComparator().getVariable();
     String comparisonVariableDataShape = util.getVariableDataShape(comparisonVariableSpec);

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/differentialexpression/DifferentialExpressionPluginProvider.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/differentialexpression/DifferentialExpressionPluginProvider.java
@@ -1,0 +1,41 @@
+package org.veupathdb.service.eda.compute.plugins.differentialexpression;
+
+import org.jetbrains.annotations.NotNull;
+import org.veupathdb.service.eda.compute.plugins.PluginContext;
+import org.veupathdb.service.eda.compute.plugins.PluginProvider;
+import org.veupathdb.service.eda.compute.plugins.PluginQueue;
+import org.veupathdb.service.eda.generated.model.DifferentialExpressionComputeConfig;
+import org.veupathdb.service.eda.generated.model.DifferentialExpressionPluginRequest;
+import org.veupathdb.service.eda.generated.model.DifferentialExpressionPluginRequestImpl;
+
+public class DifferentialExpressionPluginProvider implements PluginProvider<DifferentialExpressionPluginRequest, DifferentialExpressionComputeConfig> {
+  @NotNull
+  @Override
+  public String getUrlSegment() {
+    return "differentialexpression";
+  }
+
+  @NotNull
+  @Override
+  public String getDisplayName() {
+    return "Differential Expression Plugin";
+  }
+
+  @NotNull
+  @Override
+  public PluginQueue getTargetQueue() {
+    return PluginQueue.Slow;
+  }
+
+  @NotNull
+  @Override
+  public Class<? extends DifferentialExpressionPluginRequest> getRequestClass() {
+    return DifferentialExpressionPluginRequestImpl.class;
+  }
+
+  @NotNull
+  @Override
+  public DifferentialExpressionPlugin createPlugin(@NotNull PluginContext<DifferentialExpressionPluginRequest, DifferentialExpressionComputeConfig> context) {
+    return new DifferentialExpressionPlugin(context);
+  }
+}

--- a/src/main/java/org/veupathdb/service/eda/data/metadata/AppsMetadata.java
+++ b/src/main/java/org/veupathdb/service/eda/data/metadata/AppsMetadata.java
@@ -130,7 +130,7 @@ public class AppsMetadata {
       viz("volcanoplot", new DifferentialAbundanceVolcanoplotPlugin())),
     app("differentialexpression", "Differential Expression", "differentialexpression",
       "Find genes that are differentially expressed between two groups.",
-      NON_VB_GENOMICS_PROJECTS,
+      MBIO_PLUS_GENOMICS_PROJECTS,
       viz("volcanoplot", new DifferentialAbundanceVolcanoplotPlugin())),
     app("correlationassaymetadata", "Correlation (Taxa, Functional Data v. Metadata)", "correlation",
       "Discover relationships between metadata variables and taxonomic abundance.",

--- a/src/main/java/org/veupathdb/service/eda/data/metadata/AppsMetadata.java
+++ b/src/main/java/org/veupathdb/service/eda/data/metadata/AppsMetadata.java
@@ -8,6 +8,7 @@ import org.veupathdb.service.eda.common.plugin.constraint.ConstraintSpec;
 import org.veupathdb.service.eda.data.core.AbstractPlugin;
 import org.veupathdb.service.eda.data.plugin.correlation.CorrelationBipartitenetworkPlugin;
 import org.veupathdb.service.eda.data.plugin.differentialabundance.DifferentialAbundanceVolcanoplotPlugin;
+import org.veupathdb.service.eda.data.plugin.differentialexpression.DifferentialExpressionVolcanoplotPlugin;
 import org.veupathdb.service.eda.data.plugin.betadiv.BetaDivScatterplotPlugin;
 import org.veupathdb.service.eda.data.plugin.alphadiv.AlphaDivBoxplotPlugin;
 import org.veupathdb.service.eda.data.plugin.alphadiv.AlphaDivScatterplotPlugin;
@@ -126,6 +127,10 @@ public class AppsMetadata {
     app("differentialabundance", "Differential Abundance", "differentialabundance",
       "Find taxa or genes that are differentially abundant between two groups.",
       List.of(MICROBIOME_PROJECT),
+      viz("volcanoplot", new DifferentialAbundanceVolcanoplotPlugin())),
+    app("differentialexpression", "Differential Expression", "differentialexpression",
+      "Find genes that are differentially expressed between two groups.",
+      NON_VB_GENOMICS_PROJECTS,
       viz("volcanoplot", new DifferentialAbundanceVolcanoplotPlugin())),
     app("correlationassaymetadata", "Correlation (Taxa, Functional Data v. Metadata)", "correlation",
       "Discover relationships between metadata variables and taxonomic abundance.",

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/differentialexpression/DifferentialExpressionVolcanoplotPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/differentialexpression/DifferentialExpressionVolcanoplotPlugin.java
@@ -1,0 +1,58 @@
+package org.veupathdb.service.eda.data.plugin.differentialexpression;
+
+import org.veupathdb.service.eda.common.client.spec.StreamSpec;
+import org.veupathdb.service.eda.data.metadata.AppsMetadata;
+import org.veupathdb.service.eda.data.core.AbstractPlugin;
+import org.veupathdb.service.eda.generated.model.DifferentialExpressionComputeConfig;
+import org.veupathdb.service.eda.generated.model.DifferentialExpressionVolcanoplotPostRequest;
+import org.veupathdb.service.eda.generated.model.EmptyDataPluginSpec;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class DifferentialExpressionVolcanoplotPlugin extends AbstractPlugin<DifferentialExpressionVolcanoplotPostRequest, EmptyDataPluginSpec, DifferentialExpressionComputeConfig> {
+
+  @Override
+  public String getDisplayName() {
+    return "Volcano plot";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Display effect size vs. significance for a differential expression analysis.";
+  }
+
+  @Override
+  public List<String> getProjects() {
+    return List.of(AppsMetadata.MICROBIOME_PROJECT);
+  }
+
+  @Override
+  protected ClassGroup getTypeParameterClasses() {
+    return new ClassGroup(DifferentialExpressionVolcanoplotPostRequest.class, EmptyDataPluginSpec.class, DifferentialExpressionComputeConfig.class);
+  }
+
+  @Override
+  protected boolean computeGeneratesVars() {
+    return false;
+  }
+
+  @Override
+  protected void validateVisualizationSpec(EmptyDataPluginSpec pluginSpec) {
+    // nothing to do here
+  }
+
+  @Override
+  protected List<StreamSpec> getRequestedStreams(EmptyDataPluginSpec pluginSpec) {
+    // this plugin only uses the stats result of the compute; no tabular data streams needed
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected void writeResults(OutputStream out, Map<String, InputStream> dataStreams) {
+    writeComputeStatsResponseToOutput(out);
+  }
+}

--- a/src/main/java/org/veupathdb/service/eda/data/service/AppsService.java
+++ b/src/main/java/org/veupathdb/service/eda/data/service/AppsService.java
@@ -21,6 +21,7 @@ import org.veupathdb.service.eda.data.core.AbstractPlugin;
 import org.veupathdb.service.eda.data.plugin.correlation.CorrelationAssayAssayBipartitenetworkPlugin;
 import org.veupathdb.service.eda.data.plugin.correlation.CorrelationAssayMetadataBipartitenetworkPlugin;
 import org.veupathdb.service.eda.data.plugin.differentialabundance.DifferentialAbundanceVolcanoplotPlugin;
+import org.veupathdb.service.eda.data.plugin.differentialexpression.DifferentialExpressionVolcanoplotPlugin;
 import org.veupathdb.service.eda.data.plugin.betadiv.BetaDivScatterplotPlugin;
 import org.veupathdb.service.eda.data.plugin.correlation.CorrelationBipartitenetworkPlugin;
 import org.veupathdb.service.eda.data.plugin.selfcorrelation.SelfCorrelationUnipartitenetworkPlugin;
@@ -350,6 +351,13 @@ public class AppsService implements Apps {
   public PostAppsDifferentialabundanceVisualizationsVolcanoplotResponse postAppsDifferentialabundanceVisualizationsVolcanoplot(DifferentialAbundanceVolcanoplotPostRequest entity) {
     return wrapPlugin(() -> PostAppsDifferentialabundanceVisualizationsVolcanoplotResponse.respond200WithApplicationJson(
       new DifferentialAbundanceStatsResponseStream(processRequest(new DifferentialAbundanceVolcanoplotPlugin(), entity))));
+  }
+
+  @DisableJackson
+  @Override
+  public PostAppsDifferentialexpressionVisualizationsVolcanoplotResponse postAppsDifferentialexpressionVisualizationsVolcanoplot(DifferentialExpressionVolcanoplotPostRequest entity) {
+    return wrapPlugin(() -> PostAppsDifferentialexpressionVisualizationsVolcanoplotResponse.respond200WithApplicationJson(
+      new DifferentialExpressionStatsResponseStream(processRequest(new DifferentialExpressionVolcanoplotPlugin(), entity))));
   }
 
   @DisableJackson


### PR DESCRIPTION
Adds a differential expression compute to the "compute service".

Fully functional. Test with https://github.com/VEuPathDB/veupathUtils/pull/50

Can use

```
{
	"config": {
		"differentialExpressionMethod": "DESeq",
		"pValueFloor": "1e-200",
		"collectionVariable": {
			"entityId": "OBI_0002623",
			"collectionId": "EUPATH_0009254"
		},
		"comparator": {
			"variable": {
				"entityId": "EUPATH_0000096",
				"variableId": "EUPATH_0000639"
			},
			"groupA": [
				{
					"label": "Control"
				}
			],
			"groupB": [
				{
					"label": "Cystic fibrosis"
				}
			]
		}
	},
	"derivedVariables": [],
	"filters": [],
	"studyId": "BONUS-1"
}
```

send to `computes/differentialexpression/`


For the volcanoplot, first ensure the above computation has finished, then send the following to `apps/differentialexpression/visualizations/volcanoplot`

```
{
	"studyId": "BONUS-1",
	"filters": [],
	"config": {},
	"computeConfig": {
		"differentialExpressionMethod": "DESeq",
		"pValueFloor": "1e-200",
		"collectionVariable": {
			"entityId": "OBI_0002623",
			"collectionId": "EUPATH_0009254"
		},
		"comparator": {
			"variable": {
				"entityId": "EUPATH_0000096",
				"variableId": "EUPATH_0000639"
			},
			"groupA": [
				{
					"label": "Control"
				}
			],
			"groupB": [
				{
					"label": "Cystic fibrosis"
				}
			]
		}
	}
}
```