### PR TITLE
Add pca plot

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -432,6 +432,32 @@ securitySchemes:
             body:
               application/json: lib.DifferentialExpressionStatsResponse
 
+  /dimensionalityreduction:
+    post:
+      queryParameters:
+        autostart:
+          type: boolean
+          required: false
+          default: true
+      body:
+        application/json: lib.DimensionalityReductionPluginRequest
+      responses:
+        200:
+          body:
+            application/json: lib.JobResponse
+    /{file}:
+      uriParameters:
+        file:
+          type: string
+          description: MUST be one of "meta", "tabular", "statistics".
+      post:
+        body:
+          application/json: lib.DimensionalityReductionPluginRequest
+        responses:
+          200:
+            body:
+              text/plain: any
+
 
   /correlation:
     post:

--- a/api.raml
+++ b/api.raml
@@ -1295,6 +1295,21 @@ securitySchemes:
               application/json:
                 type: lib.DifferentialExpressionStatsResponse
 
+  /dimensionalityreduction/visualizations:
+    displayName: Visualizations for understanding patterns in the data
+
+    /scatterplot:
+      post:
+        description: Returns data required to create a scatterplot from a dimensionality reduction analysis.
+        body:
+          application/json:
+            type: lib.DimensionalityReductionScatterplotPostRequest
+        responses:
+          200:
+            body:
+              application/json:
+                type: lib.ScatterplotPostResponse
+
   /correlation/visualizations:
     displayName: Visualizations for discovering correlations between various assay data
 

--- a/schema/library.raml
+++ b/schema/library.raml
@@ -478,6 +478,7 @@ types:
       - geo
       - latitude
       - longitude
+      - undefined
   VariableMapping:
     type: object
     additionalProperties: false

--- a/schema/library.raml
+++ b/schema/library.raml
@@ -1209,6 +1209,15 @@ types:
     properties:
       effectSizeLabel: string
       statistics: DifferentialExpressionPoint[]
+  DimensionalityReductionPluginRequest:
+    type: ComputeRequestBase
+    properties:
+      config: DimensionalityReductionComputeConfig
+  DimensionalityReductionComputeConfig:
+    type: object
+    properties:
+      collectionVariable: CollectionSpec
+      nPCs: number
   ExamplePluginRequest:
     type: ComputeRequestBase
     properties:
@@ -1420,6 +1429,11 @@ types:
     properties:
       computeConfig: DifferentialExpressionComputeConfig
       config: EmptyDataPluginSpec
+  DimensionalityReductionScatterplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: DimensionalityReductionComputeConfig
+      # config: ScatterplotWith1ComputeSpec Ann change
   ContinuousVariableMetadataPostRequest:
     type: DataPluginRequestBase
     additionalProperties: false

--- a/schema/library.raml
+++ b/schema/library.raml
@@ -1433,7 +1433,24 @@ types:
     type: DataPluginRequestBase
     properties:
       computeConfig: DimensionalityReductionComputeConfig
-      # config: ScatterplotWith1ComputeSpec Ann change
+      config: DimensionalityReductionScatterplotSpec
+  DimensionalityReductionScatterplotSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      showMissingness:
+        type: ShowMissingnessNoAxes
+        required: false
+      xAxisSelection:
+        type: string
+        required: false
+      yAxisSelection:
+        type: string
+        required: false
+      overlayVariable:
+        type: VariableSpec
+        required: false
   ContinuousVariableMetadataPostRequest:
     type: DataPluginRequestBase
     additionalProperties: false

--- a/schema/url/common/compute.raml
+++ b/schema/url/common/compute.raml
@@ -54,7 +54,7 @@ types:
     enum: [ 'native', 'derived', 'computed' ]
 
   PlotReferenceValue:
-    enum: [ 'xAxis', 'yAxis', 'zAxis', 'overlay', 'facet1', 'facet2', 'geo', 'latitude', 'longitude']
+    enum: [ 'xAxis', 'yAxis', 'zAxis', 'overlay', 'facet1', 'facet2', 'geo', 'latitude', 'longitude', 'undefined']
 
   VariableMapping:
     additionalProperties: false

--- a/schema/url/compute/computes/dimensionalityReduction.raml
+++ b/schema/url/compute/computes/dimensionalityReduction.raml
@@ -1,0 +1,19 @@
+#%RAML 1.0 Library
+
+types:
+
+  DimensionalityReductionPluginRequest:
+    type: ComputeRequestBase
+    properties:
+      config: DimensionalityReductionComputeConfig
+
+  DimensionalityReductionComputeConfig:
+    properties:
+      collectionVariable: CollectionSpec
+      nPCs: number
+      # DimensionalityReductionMethod: DimensionalityReductionMethod
+
+# For future use
+  # DimensionalityReductionMethod:
+  #   type: string
+  #   enum: ['pca', 'pcoa', 'mapper']

--- a/schema/url/data/dimensionalityreduction/plugin-dimensionalityreduction-scatterplot.raml
+++ b/schema/url/data/dimensionalityreduction/plugin-dimensionalityreduction-scatterplot.raml
@@ -7,4 +7,25 @@ types:
     type: DataPluginRequestBase
     properties:
       computeConfig: DimensionalityReductionComputeConfig
-      # config: ScatterplotWith1ComputeSpec Ann change
+      config: DimensionalityReductionScatterplotSpec
+
+  # This scatterplot is a little different because the frontend says
+  # which dimensions to plot, instead of selecting variables for the x and y axes.
+  DimensionalityReductionScatterplotSpec:
+    additionalProperties: false
+    properties:
+      outputEntityId:
+        type: string
+      showMissingness:
+        type: ShowMissingnessNoAxes
+        required: false
+      xAxisSelection:
+        type: string
+        required: false
+      yAxisSelection:
+        type: string
+        required: false
+      overlayVariable:
+        type: VariableSpec
+        required: false
+      

--- a/schema/url/data/dimensionalityreduction/plugin-dimensionalityreduction-scatterplot.raml
+++ b/schema/url/data/dimensionalityreduction/plugin-dimensionalityreduction-scatterplot.raml
@@ -1,0 +1,10 @@
+#%RAML 1.0 Library
+
+types:
+  # Type name determines the name of the Java class that will be generated.
+
+  DimensionalityReductionScatterplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: DimensionalityReductionComputeConfig
+      # config: ScatterplotWith1ComputeSpec Ann change

--- a/src/main/java/org/veupathdb/service/eda/compute/controller/ComputeController.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/controller/ComputeController.java
@@ -22,6 +22,7 @@ import org.veupathdb.service.eda.compute.plugins.betadiv.BetaDivPluginProvider;
 import org.veupathdb.service.eda.compute.plugins.correlation.CorrelationPluginProvider;
 import org.veupathdb.service.eda.compute.plugins.differentialabundance.DifferentialAbundancePluginProvider;
 import org.veupathdb.service.eda.compute.plugins.differentialexpression.DifferentialExpressionPluginProvider;
+import org.veupathdb.service.eda.compute.plugins.dimensionalityreduction.DimensionalityReductionPluginProvider;
 import org.veupathdb.service.eda.compute.plugins.example.ExamplePluginProvider;
 import org.veupathdb.service.eda.compute.plugins.rankedabundance.RankedAbundancePluginProvider;
 import org.veupathdb.service.eda.compute.plugins.selfcorrelation.SelfCorrelationPluginProvider;
@@ -150,6 +151,16 @@ public class ComputeController implements Computes {
         throw new RuntimeException(e);
       }
     }));
+  }
+
+  @Override
+  public PostComputesDimensionalityreductionResponse postComputesDimensionalityreduction(Boolean autostart, DimensionalityReductionPluginRequest entity) {
+    return PostComputesDimensionalityreductionResponse.respond200WithApplicationJson(submitJob(new DimensionalityReductionPluginProvider(), entity, autostart));
+  }
+
+  @Override
+  public PostComputesDimensionalityreductionByFileResponse postComputesDimensionalityreductionByFile(String file, DimensionalityReductionPluginRequest entity) {
+    return resultFile(new DimensionalityReductionPluginProvider(), file, entity, PostComputesDimensionalityreductionByFileResponse::respond200WithTextPlain);
   }
 
   @Override

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/PluginRegistry.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/PluginRegistry.java
@@ -12,6 +12,7 @@ import org.veupathdb.service.eda.compute.plugins.example.ExamplePluginProvider;
 import org.veupathdb.service.eda.compute.plugins.rankedabundance.RankedAbundancePluginProvider;
 import org.veupathdb.service.eda.compute.plugins.differentialabundance.DifferentialAbundancePluginProvider;
 import org.veupathdb.service.eda.compute.plugins.differentialexpression.DifferentialExpressionPluginProvider;
+import org.veupathdb.service.eda.compute.plugins.dimensionalityreduction.DimensionalityReductionPluginProvider;
 import org.veupathdb.service.eda.generated.model.ComputeRequestBase;
 import org.veupathdb.service.eda.generated.model.PluginOverview;
 import org.veupathdb.service.eda.generated.model.PluginOverviewImpl;
@@ -52,6 +53,7 @@ public final class PluginRegistry {
       new RankedAbundancePluginProvider(),
       new DifferentialAbundancePluginProvider(),
       new DifferentialExpressionPluginProvider(),
+      new DimensionalityReductionPluginProvider(),
       new CorrelationPluginProvider(),
       new SelfCorrelationPluginProvider()
     );

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/dimensionalityreduction/DimensionalityReductionPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/dimensionalityreduction/DimensionalityReductionPlugin.java
@@ -47,7 +47,7 @@ public class DimensionalityReductionPlugin extends AbstractPlugin<Dimensionality
     EntityDef entity = meta.getEntity(entityId).orElseThrow();
     VariableDef computeEntityIdVarSpec = util.getEntityIdVarSpec(entityId);
     String computeEntityIdColName = util.toColNameOrEmpty(computeEntityIdVarSpec);
-    String nPCs = computeConfig.getNPCs() == null ? "5" : computeConfig.getNPCs().toString();
+    String nPCs = computeConfig.getNPCs() == null ? "2" : computeConfig.getNPCs().toString();
     HashMap<String, InputStream> dataStream = new HashMap<>();
     dataStream.put(INPUT_DATA, getWorkspace().openStream(INPUT_DATA));
     List<VariableDef> idColumns = new ArrayList<>();

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/dimensionalityreduction/DimensionalityReductionPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/dimensionalityreduction/DimensionalityReductionPlugin.java
@@ -1,0 +1,93 @@
+package org.veupathdb.service.eda.compute.plugins.dimensionalityreduction;
+
+import org.gusdb.fgputil.ListBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.veupathdb.service.eda.common.client.spec.StreamSpec;
+import org.veupathdb.service.eda.common.model.CollectionDef;
+import org.veupathdb.service.eda.common.model.EntityDef;
+import org.veupathdb.service.eda.common.model.ReferenceMetadata;
+import org.veupathdb.service.eda.common.model.VariableDef;
+import org.veupathdb.service.eda.common.plugin.util.PluginUtil;
+import org.veupathdb.service.eda.compute.RServe;
+import org.veupathdb.service.eda.compute.plugins.AbstractPlugin;
+import org.veupathdb.service.eda.compute.plugins.PluginContext;
+import org.veupathdb.service.eda.generated.model.DimensionalityReductionComputeConfig;
+import org.veupathdb.service.eda.generated.model.DimensionalityReductionPluginRequest;
+import org.veupathdb.service.eda.generated.model.VariableSpec;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class DimensionalityReductionPlugin extends AbstractPlugin<DimensionalityReductionPluginRequest, DimensionalityReductionComputeConfig> {
+
+  private static final String INPUT_DATA = "dimensionality_reduction_input";
+
+  public DimensionalityReductionPlugin(@NotNull PluginContext<DimensionalityReductionPluginRequest, DimensionalityReductionComputeConfig> context) {
+    super(context);
+  }
+
+  @NotNull
+  @Override
+  public List<StreamSpec> getStreamSpecs() {
+    return List.of(new StreamSpec(INPUT_DATA, getConfig().getCollectionVariable().getEntityId())
+      .addVars(getUtil().getCollectionMembers(getConfig().getCollectionVariable())));
+  }
+
+  @Override
+  protected void execute() {
+
+    DimensionalityReductionComputeConfig computeConfig = getConfig();
+    PluginUtil util = getUtil();
+    ReferenceMetadata meta = getContext().getReferenceMetadata();
+    CollectionDef collection = meta.getCollection(computeConfig.getCollectionVariable()).orElseThrow();
+    String collectionMemberType = collection.getMember() == null ? "unknown" : collection.getMember();
+    String entityId = computeConfig.getCollectionVariable().getEntityId();
+    EntityDef entity = meta.getEntity(entityId).orElseThrow();
+    VariableDef computeEntityIdVarSpec = util.getEntityIdVarSpec(entityId);
+    String computeEntityIdColName = util.toColNameOrEmpty(computeEntityIdVarSpec);
+    String nPCs = computeConfig.getNPCs() == null ? "5" : computeConfig.getNPCs().toString();
+    HashMap<String, InputStream> dataStream = new HashMap<>();
+    dataStream.put(INPUT_DATA, getWorkspace().openStream(INPUT_DATA));
+    List<VariableDef> idColumns = new ArrayList<>();
+    for (EntityDef ancestor : meta.getAncestors(entity)) {
+      idColumns.add(ancestor.getIdColumnDef());
+    }
+
+    RServe.useRConnectionWithRemoteFiles(dataStream, connection -> {
+      connection.voidEval("print('starting dimensionality reduction computation')");
+
+      List<VariableSpec> computeInputVars = ListBuilder.asList(computeEntityIdVarSpec);
+      computeInputVars.addAll(util.getCollectionMembers(computeConfig.getCollectionVariable()));
+      computeInputVars.addAll(idColumns);
+      connection.voidEval(util.getVoidEvalFreadCommand(INPUT_DATA, computeInputVars));
+      List<String> dotNotatedIdColumns = idColumns.stream().map(VariableDef::toDotNotation).toList();
+      StringBuilder dotNotatedIdColumnsString = new StringBuilder("c(");
+      boolean first = true;
+      for (String idCol : dotNotatedIdColumns) {
+        if (first) {
+          first = false;
+          dotNotatedIdColumnsString.append(PluginUtil.singleQuote(idCol));
+        } else {
+          dotNotatedIdColumnsString.append(",").append(PluginUtil.singleQuote(idCol));
+        }
+      }
+      dotNotatedIdColumnsString.append(")");
+
+      connection.voidEval("abundDT <- microbiomeComputations::AbundanceData(name=" + PluginUtil.singleQuote(collectionMemberType) + ",data=" + INPUT_DATA +
+        ",recordIdColumn=" + PluginUtil.singleQuote(computeEntityIdColName) +
+        ",ancestorIdColumns=as.character(" + dotNotatedIdColumnsString + ")" +
+        ",imputeZero=TRUE)");
+
+      connection.voidEval("pcaOutput <- veupathUtils::pca(abundDT, " +
+        "nPCs=" + PluginUtil.singleQuote(nPCs) + ", " +
+        "verbose=TRUE)");
+      String dataCmd = "writeData(pcaOutput, NULL, TRUE)";
+      String metaCmd = "writeMeta(pcaOutput, NULL, TRUE)";
+
+      getWorkspace().writeDataResult(connection, dataCmd);
+      getWorkspace().writeMetaResult(connection, metaCmd);
+    });
+  }
+}

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/dimensionalityreduction/DimensionalityReductionPluginProvider.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/dimensionalityreduction/DimensionalityReductionPluginProvider.java
@@ -1,0 +1,42 @@
+package org.veupathdb.service.eda.compute.plugins.dimensionalityreduction;
+
+import org.jetbrains.annotations.NotNull;
+import org.veupathdb.service.eda.compute.plugins.PluginContext;
+import org.veupathdb.service.eda.compute.plugins.PluginProvider;
+import org.veupathdb.service.eda.compute.plugins.PluginQueue;
+import org.veupathdb.service.eda.generated.model.DimensionalityReductionComputeConfig;
+import org.veupathdb.service.eda.generated.model.DimensionalityReductionPluginRequest;
+import org.veupathdb.service.eda.generated.model.DimensionalityReductionPluginRequestImpl;
+
+public class DimensionalityReductionPluginProvider implements PluginProvider<DimensionalityReductionPluginRequest, DimensionalityReductionComputeConfig> {
+
+  @NotNull
+  @Override
+  public String getUrlSegment() {
+    return "dimensionalityreduction";
+  }
+
+  @NotNull
+  @Override
+  public String getDisplayName() {
+    return "Dimensionality Reduction Plugin";
+  }
+
+  @NotNull
+  @Override
+  public PluginQueue getTargetQueue() {
+    return PluginQueue.Fast;
+  }
+
+  @NotNull
+  @Override
+  public Class<? extends DimensionalityReductionPluginRequest> getRequestClass() {
+    return DimensionalityReductionPluginRequestImpl.class;
+  }
+
+  @NotNull
+  @Override
+  public DimensionalityReductionPlugin createPlugin(@NotNull PluginContext<DimensionalityReductionPluginRequest, DimensionalityReductionComputeConfig> context) {
+    return new DimensionalityReductionPlugin(context);
+  }
+}

--- a/src/main/java/org/veupathdb/service/eda/data/metadata/AppsMetadata.java
+++ b/src/main/java/org/veupathdb/service/eda/data/metadata/AppsMetadata.java
@@ -9,6 +9,7 @@ import org.veupathdb.service.eda.data.core.AbstractPlugin;
 import org.veupathdb.service.eda.data.plugin.correlation.CorrelationBipartitenetworkPlugin;
 import org.veupathdb.service.eda.data.plugin.differentialabundance.DifferentialAbundanceVolcanoplotPlugin;
 import org.veupathdb.service.eda.data.plugin.differentialexpression.DifferentialExpressionVolcanoplotPlugin;
+import org.veupathdb.service.eda.data.plugin.dimensionalityreduction.DimensionalityReductionScatterplotPlugin;
 import org.veupathdb.service.eda.data.plugin.betadiv.BetaDivScatterplotPlugin;
 import org.veupathdb.service.eda.data.plugin.alphadiv.AlphaDivBoxplotPlugin;
 import org.veupathdb.service.eda.data.plugin.alphadiv.AlphaDivScatterplotPlugin;
@@ -132,6 +133,10 @@ public class AppsMetadata {
       "Find genes that are differentially expressed between two groups.",
       MBIO_PLUS_GENOMICS_PROJECTS,
       viz("volcanoplot", new DifferentialAbundanceVolcanoplotPlugin())),
+    app("dimensionalityreduction", "Dimensionality Reduction", "dimensionalityreduction",
+      "Investigate dataset features using dimensionality reduction techniques.",
+      MBIO_PLUS_GENOMICS_PROJECTS,
+      viz("scatterplot", new DimensionalityReductionScatterplotPlugin())),
     app("correlationassaymetadata", "Correlation (Taxa, Functional Data v. Metadata)", "correlation",
       "Discover relationships between metadata variables and taxonomic abundance.",
       List.of(MICROBIOME_PROJECT),

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/dimensionalityreduction/DimensionalityReductionScatterplotPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/dimensionalityreduction/DimensionalityReductionScatterplotPlugin.java
@@ -1,0 +1,120 @@
+package org.veupathdb.service.eda.data.plugin.dimensionalityreduction;
+
+import org.veupathdb.service.eda.common.client.spec.StreamSpec;
+import org.veupathdb.service.eda.common.plugin.constraint.ConstraintSpec;
+import org.veupathdb.service.eda.common.plugin.constraint.DataElementSet;
+import org.veupathdb.service.eda.common.plugin.util.RServeClient;
+import org.veupathdb.service.eda.Resources;
+import org.veupathdb.service.eda.data.metadata.AppsMetadata;
+import org.veupathdb.service.eda.data.core.AbstractPlugin;
+import org.veupathdb.service.eda.generated.model.*;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.veupathdb.service.eda.common.plugin.util.RServeClient.useRConnectionWithRemoteFiles;
+
+public class DimensionalityReductionScatterplotPlugin extends AbstractPlugin<DimensionalityReductionScatterplotPostRequest, DimensionalityReductionScatterplotSpec, DimensionalityReductionComputeConfig> {
+
+  @Override
+  public String getDisplayName() {
+    return "Dimensional reduction scatter plot";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Visualize a 2-dimensional projection of samples based on their beta diversitiy";
+  }
+
+  @Override
+  public List<String> getProjects() {
+    return List.of(AppsMetadata.MICROBIOME_PROJECT);
+  }
+
+  @Override
+  protected ClassGroup getTypeParameterClasses() {
+    return new ClassGroup(DimensionalityReductionScatterplotPostRequest.class, DimensionalityReductionScatterplotSpec.class, DimensionalityReductionComputeConfig.class);
+  }
+
+  @Override
+  public ConstraintSpec getConstraintSpec() {
+    return new ConstraintSpec()
+      .dependencyOrder(List.of("yAxisVariable", "xAxisVariable"), List.of("overlayVariable"))
+      .pattern()
+        .element("overlayVariable")
+          .required(false)
+          .maxValues(8)
+          .description("Variable must be a number, or have 8 or fewer values, and be of the same or a parent entity as the X-axis variable.")
+      .pattern()
+        .element("overlayVariable")
+          .required(false)
+          .types(APIVariableType.NUMBER, APIVariableType.INTEGER)
+          .description("Variable must be a number, or have 8 or fewer values, and be of the same or a parent entity as the X-axis variable.")
+      .done();
+  }
+
+  @Override
+  protected void validateVisualizationSpec(DimensionalityReductionScatterplotSpec pluginSpec) {
+    validateInputs(new DataElementSet()
+      .entity(pluginSpec.getOutputEntityId())
+      .var("overlayVariable", pluginSpec.getOverlayVariable()));
+  }
+
+  @Override
+  protected List<StreamSpec> getRequestedStreams(DimensionalityReductionScatterplotSpec pluginSpec) {
+    System.out.println("getRequestedStreams");
+    System.out.println(List.of(
+      new StreamSpec(DEFAULT_SINGLE_STREAM_NAME, pluginSpec.getOutputEntityId())
+        .addVar(pluginSpec.getOverlayVariable())
+        .setIncludeComputedVars(true)
+    ));
+    return List.of(
+      new StreamSpec(DEFAULT_SINGLE_STREAM_NAME, pluginSpec.getOutputEntityId())
+        .addVar(pluginSpec.getOverlayVariable())
+        .setIncludeComputedVars(true)
+    );
+  }
+
+  @Override
+  protected void writeResults(OutputStream out, Map<String, InputStream> dataStreams) {
+    System.out.println("writeResults");
+    DimensionalityReductionScatterplotSpec spec = getPluginSpec();
+    Map<String, VariableSpec> varMap = new HashMap<>();
+    varMap.put("overlay", spec.getOverlayVariable());
+    String valueSpec = "raw";
+    String showMissingness = spec.getShowMissingness() != null
+      ? spec.getShowMissingness().getValue()
+      : "noVariables";
+    String deprecatedShowMissingness = showMissingness.equals("FALSE")
+      ? "noVariables"
+      : showMissingness.equals("TRUE")
+        ? "strataVariables"
+        : showMissingness;
+
+    ComputedVariableMetadata metadata = getComputedVariableMetadata();
+    // VariableSpec xComputedVarSpec = metadata.getVariables().stream()
+    //     .filter(var -> var.getPlotReference().getValue().equals("xAxis"))
+    //     .findFirst().orElseThrow().getVariableSpec();
+    // VariableSpec yComputedVarSpec = metadata.getVariables().stream()
+    //     .filter(var -> var.getPlotReference().getValue().equals("yAxis"))
+    //     .findFirst().orElseThrow().getVariableSpec();
+
+    useRConnectionWithRemoteFiles(Resources.RSERVE_URL, dataStreams, connection -> {
+      connection.voidEval(getUtil().getVoidEvalFreadCommand(DEFAULT_SINGLE_STREAM_NAME,
+          spec.getOverlayVariable()));
+
+      connection.voidEval(getVoidEvalVariableMetadataList(varMap));
+      connection.voidEval(getVoidEvalComputedVariableMetadataList(metadata));
+      connection.voidEval("variables <- veupathUtils::merge(variables, computedVariables)");
+
+      String command = "plot.data::scattergl(" + DEFAULT_SINGLE_STREAM_NAME + ", variables, '" +
+        valueSpec +
+        "', overlayValues=NULL, correlationMethod = 'none', sampleSizes=TRUE, completeCases=TRUE, '" +
+        deprecatedShowMissingness + "')";
+      RServeClient.streamResult(connection, command, out);
+    });
+  }
+}

--- a/src/main/java/org/veupathdb/service/eda/data/service/AppsService.java
+++ b/src/main/java/org/veupathdb/service/eda/data/service/AppsService.java
@@ -27,6 +27,7 @@ import org.veupathdb.service.eda.data.plugin.correlation.CorrelationAssayMetadat
 import org.veupathdb.service.eda.data.plugin.correlation.CorrelationBipartitenetworkPlugin;
 import org.veupathdb.service.eda.data.plugin.differentialabundance.DifferentialAbundanceVolcanoplotPlugin;
 import org.veupathdb.service.eda.data.plugin.differentialexpression.DifferentialExpressionVolcanoplotPlugin;
+import org.veupathdb.service.eda.data.plugin.dimensionalityreduction.DimensionalityReductionScatterplotPlugin;
 import org.veupathdb.service.eda.data.plugin.pass.*;
 import org.veupathdb.service.eda.data.plugin.sample.*;
 import org.veupathdb.service.eda.data.plugin.selfcorrelation.SelfCorrelationUnipartitenetworkPlugin;
@@ -355,6 +356,13 @@ public class AppsService implements Apps {
   public PostAppsDifferentialexpressionVisualizationsVolcanoplotResponse postAppsDifferentialexpressionVisualizationsVolcanoplot(DifferentialExpressionVolcanoplotPostRequest entity) {
     return wrapPlugin(() -> PostAppsDifferentialexpressionVisualizationsVolcanoplotResponse.respond200WithApplicationJson(
       new DifferentialExpressionStatsResponseStream(processRequest(new DifferentialExpressionVolcanoplotPlugin(), entity))));
+  }
+
+  @DisableJackson
+  @Override
+  public PostAppsDimensionalityreductionVisualizationsScatterplotResponse postAppsDimensionalityreductionVisualizationsScatterplot(DimensionalityReductionScatterplotPostRequest entity) {
+    return wrapPlugin(() -> PostAppsDimensionalityreductionVisualizationsScatterplotResponse.respond200WithApplicationJson(
+      new ScatterplotPostResponseStream(processRequest(new DimensionalityReductionScatterplotPlugin(), entity))));
   }
 
   @DisableJackson


### PR DESCRIPTION
Adds a pca compute and viz plugin. Currently relies on [this version](https://github.com/VEuPathDB/veupathUtils/pull/56) of `veupathUtils`.

I'm wrapping this up for now. Not completed:
- overlay variable testing
- narrowing down from lots of PCs to 2. The compute metadata for all requested PCs is fed to plot.data, which gets angry because some have redundant plotReference values. What we need to do is filter the `computedMetadata` so that it only contains the two requested PCs.
