### PR TITLE
Ask scatterplot to return the record ids of each point

### DIFF
--- a/schema/library.raml
+++ b/schema/library.raml
@@ -1956,6 +1956,9 @@ types:
         required: false
         format: int64
       correlationMethod: ScatterCorrelationMethod
+      returnPointIds:
+        type: boolean
+        required: false
   Scatterplot:
     type: object
     additionalProperties: false

--- a/schema/library.raml
+++ b/schema/library.raml
@@ -2239,6 +2239,9 @@ types:
       r2:
         type: number
         required: false
+      pointIds:
+        type: string[]
+        required: false
   DensityplotData:
     type: object
     additionalProperties: false

--- a/schema/url/data/pass/plugin-scatterplot.raml
+++ b/schema/url/data/pass/plugin-scatterplot.raml
@@ -40,6 +40,9 @@ types:
         required: false
       correlationMethod:
         type: ScatterCorrelationMethod
+      returnPointIds:
+        type: boolean
+        required: false
 
   Scatterplot:
     additionalProperties: false

--- a/schema/url/data/plots.raml
+++ b/schema/url/data/plots.raml
@@ -243,6 +243,9 @@ types:
       r2:
         type: number
         required: false
+      pointIds:
+        type: string[]
+        required: false
 
   DensityplotData:
     additionalProperties: false

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/pass/ScatterplotPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/pass/ScatterplotPlugin.java
@@ -124,6 +124,7 @@ public class ScatterplotPlugin extends AbstractEmptyComputePlugin<ScatterplotPos
     String yVarType = util.getVariableType(spec.getYAxisVariable());
     String correlationMethod = spec.getCorrelationMethod() != null ? spec.getCorrelationMethod().getValue() : "none";
     String recordIdColumnName = util.toColNameOrEmpty(util.getEntityIdVarSpec(spec.getOutputEntityId()));
+    String returnPointIds = spec.getReturnPointIds() != null ? String.valueOf(spec.getReturnPointIds()).toUpperCase() : "FALSE";
 
     if (yVarType.equals("DATE") && !valueSpec.equals("raw")) {
       LOG.error("Cannot calculate trend lines for y-axis date variables. The `valueSpec` property must be set to `raw`.");
@@ -150,9 +151,6 @@ public class ScatterplotPlugin extends AbstractEmptyComputePlugin<ScatterplotPos
 
     useRConnectionWithProcessedRemoteFiles(Resources.RSERVE_URL, filesProcessor, connection -> {
       connection.voidEval(getVoidEvalVariableMetadataList(varMap));
-      connection.voidEval("print(head(" + DEFAULT_SINGLE_STREAM_NAME + "))");
-      connection.voidEval("print("+DEFAULT_SINGLE_STREAM_NAME+ ")");
-      connection.voidEval("print('"+recordIdColumnName+"')");
       String cmd =
           "plot.data::scattergl(" + 
             DEFAULT_SINGLE_STREAM_NAME +
@@ -163,9 +161,8 @@ public class ScatterplotPlugin extends AbstractEmptyComputePlugin<ScatterplotPos
             "', sampleSizes=TRUE, completeCases=TRUE" +
             ", evilMode='" + deprecatedShowMissingness + 
             "', idColumn = '" + recordIdColumnName + 
-            "', returnPointIds = TRUE)";
-      System.out.println(cmd);
-      // connection.voidEval("print('"+ cmd + "')");
+            "', returnPointIds = " + returnPointIds + ")";
+
       streamResult(connection, cmd, out);
     });
   }

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/pass/ScatterplotPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/pass/ScatterplotPlugin.java
@@ -123,6 +123,7 @@ public class ScatterplotPlugin extends AbstractEmptyComputePlugin<ScatterplotPos
     String deprecatedShowMissingness = showMissingness.equals("FALSE") ? "noVariables" : showMissingness.equals("TRUE") ? "strataVariables" : showMissingness;
     String yVarType = util.getVariableType(spec.getYAxisVariable());
     String correlationMethod = spec.getCorrelationMethod() != null ? spec.getCorrelationMethod().getValue() : "none";
+    String recordIdColumnName = util.toColNameOrEmpty(util.getEntityIdVarSpec(spec.getOutputEntityId()));
 
     if (yVarType.equals("DATE") && !valueSpec.equals("raw")) {
       LOG.error("Cannot calculate trend lines for y-axis date variables. The `valueSpec` property must be set to `raw`.");
@@ -139,6 +140,7 @@ public class ScatterplotPlugin extends AbstractEmptyComputePlugin<ScatterplotPos
         nonStrataVarColNames,
         (name, conn) ->
         conn.voidEval(util.getVoidEvalFreadCommand(name,
+          util.getEntityIdVarSpec(spec.getOutputEntityId()),
           spec.getXAxisVariable(),
           spec.getYAxisVariable(),
           spec.getOverlayVariable(),
@@ -148,10 +150,22 @@ public class ScatterplotPlugin extends AbstractEmptyComputePlugin<ScatterplotPos
 
     useRConnectionWithProcessedRemoteFiles(Resources.RSERVE_URL, filesProcessor, connection -> {
       connection.voidEval(getVoidEvalVariableMetadataList(varMap));
+      connection.voidEval("print(head(" + DEFAULT_SINGLE_STREAM_NAME + "))");
+      connection.voidEval("print("+DEFAULT_SINGLE_STREAM_NAME+ ")");
+      connection.voidEval("print('"+recordIdColumnName+"')");
       String cmd =
-          "plot.data::scattergl(" + DEFAULT_SINGLE_STREAM_NAME + ", variables, '" +
-              valueSpec + "', NULL, correlationMethod = '" + correlationMethod + "', TRUE, TRUE, '" +
-              deprecatedShowMissingness + "')";
+          "plot.data::scattergl(" + 
+            DEFAULT_SINGLE_STREAM_NAME +
+            ", variables" +
+            ", value= '" + valueSpec +
+            "', overlayValues = NULL" + 
+            ", correlationMethod = '" + correlationMethod + 
+            "', sampleSizes=TRUE, completeCases=TRUE" +
+            ", evilMode='" + deprecatedShowMissingness + 
+            "', idColumn = '" + recordIdColumnName + 
+            "', returnPointIds = TRUE)";
+      System.out.println(cmd);
+      // connection.voidEval("print('"+ cmd + "')");
       streamResult(connection, cmd, out);
     });
   }


### PR DESCRIPTION
This feature will be useful for highlighting a specific point in a scatterplot. Relies on https://github.com/VEuPathDB/plot.data/pull/264

Status:
- successful response!
- need to add api and ensure normal scatters are _not_ getting the extra ids back.