### PR TITLE
Add returnPointIds as optional for all scatter apis

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
   id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
-// configure VEupathDB container plugin
 containerBuild {
   // General project level configuration.
   project {

--- a/schema/library.raml
+++ b/schema/library.raml
@@ -1331,6 +1331,9 @@ types:
       overlayVariable:
         type: VariableSpec
         required: false
+      returnPointIds:
+        type: boolean
+        required: false
   CorrelationNetworkSpec:
     type: object
     additionalProperties: false
@@ -3006,6 +3009,9 @@ types:
       facetVariable:
         type: VariableSpec[]
         maxItems: 2
+        required: false
+      returnPointIds:
+        type: boolean
         required: false
   Aggregator:
     type: string

--- a/schema/url/data/betadiv/plugin-betadiv-scatterplot.raml
+++ b/schema/url/data/betadiv/plugin-betadiv-scatterplot.raml
@@ -21,3 +21,6 @@ types:
       overlayVariable:
         type: VariableSpec
         required: false
+      returnPointIds:
+        type: boolean
+        required: false

--- a/schema/url/data/visualizations.raml
+++ b/schema/url/data/visualizations.raml
@@ -158,6 +158,9 @@ types:
         type: VariableSpec[]
         maxItems: 2
         required: false
+      returnPointIds:
+        type: boolean
+        required: false
 
   Aggregator:
     type: string


### PR DESCRIPTION
Found this bug on QA. For any scatterplot that's used in an app we get this error:
<img width="1154" alt="Screen Shot 2025-03-27 at 11 59 21 PM" src="https://github.com/user-attachments/assets/70cc601c-0b87-4f86-a217-34437354b2e4" />

When I added `returnPointIds` to the scatterplot api I forgot to add it to the api for the scatterplots used in the apps. So this PR adds `returnPointIds` to the scatterplot apis of the app scatterplots (beta div, ranked abundance, etc).

Tested with local frontend.
