### PR TITLE
add correlationDirection for correlation networks

### DIFF
--- a/schema/library.raml
+++ b/schema/library.raml
@@ -7,30 +7,450 @@
 ################################################################################
 
 types:
-  DatastoreId:
-    type: integer
-    format: int64
-    minimum: 1
-  UserDetails:
+  API_BooleanOperationType:
+    type: string
+    enum:
+      - intersect
+      - union
+  API_Collection:
+    type: object
+    discriminator: type
+    properties:
+      id: string
+      displayName: string
+      type: API_CollectionType
+      dataShape: API_VariableDataShape
+      vocabulary?: string[]
+      distinctValuesCount?:
+        type: integer
+        format: int64
+      memberVariableIds: string[]
+      imputeZero: boolean
+      normalizationMethod: string
+      isCompositional: boolean
+      isProportion: boolean
+      variableSpecToImputeZeroesFor?: VariableSpec
+      member: string
+      memberPlural: string
+  API_CollectionType:
+    type: string
+    enum:
+      - number
+      - date
+      - integer
+      - string
+  API_DateCollection:
+    type: API_Collection
+    discriminatorValue: date
+    properties:
+      distributionDefaults: API_DateDistributionDefaults
+  API_DateDistributionDefaults:
+    type: object
+    properties:
+      displayRangeMin?: string
+      displayRangeMax?: string
+      rangeMin?: string
+      rangeMax?: string
+      binWidth?: integer
+      binWidthOverride?: integer
+      binUnits?: BinUnits
+  API_DateRangeFilter:
+    type: API_Filter
+    discriminatorValue: 'dateRange'
+    properties:
+      variableId: string
+      min: string
+      max: string
+  API_DateSetFilter:
+    type: API_Filter
+    discriminatorValue: 'dateSet'
+    properties:
+      variableId: string
+      dateSet: string[] # how to constrain this to a date?
+  API_DateVariable:
+    type: API_VariableWithValues
+    discriminatorValue: date
+    properties:
+      distributionDefaults: API_DateDistributionDefaults
+  API_Entity:
+    type: EntityIdGetResponse
+    properties:
+      children?: API_Entity[]
+  API_Filter:
+    type: object
+    discriminator: type
+    properties:
+      entityId: string
+      type: API_FilterType
+  API_FilterType:
+    type: string
+    enum:
+      - stringSet
+      - numberSet
+      - dateSet
+      - numberRange
+      - dateRange
+      - longitudeRange
+      - multiFilter
+  API_IntegerCollection:
+    type: API_Collection
+    discriminatorValue: integer
+    properties:
+      distributionDefaults: API_IntegerDistributionDefaults
+      units: string
+  API_IntegerDistributionDefaults:
+    type: object
+    properties:
+      displayRangeMin?:
+        type: integer
+        format: int64
+      displayRangeMax?:
+        type: integer
+        format: int64
+      rangeMin?:
+        type: integer
+        format: int64
+      rangeMax?:
+        type: integer
+        format: int64
+      binWidth?:
+        type: integer
+        format: int64
+      binWidthOverride?:
+        type: integer
+        format: int64
+  API_IntegerVariable:
+    type: API_VariableWithValues
+    discriminatorValue: integer
+    properties:
+      distributionDefaults: API_IntegerDistributionDefaults
+      units?: string
+  API_LongitudeRangeFilter:
+    type: API_Filter
+    discriminatorValue: 'longitudeRange'
+    properties:
+      variableId: string
+      left: number
+      right: number
+  API_LongitudeVariable:
+    type: API_VariableWithValues
+    discriminatorValue: longitude
+    properties:
+      precision: number
+  API_MultiFilter:
+    type: API_Filter
+    discriminatorValue: 'multiFilter'
+    properties:
+      operation: API_BooleanOperationType
+      variableId: string
+      subFilters: API_MultiFilterSubFilter[]
+  API_MultiFilterSubFilter:
+    type: object
+    properties:
+      variableId: string
+      stringSet: string[]
+  API_NumberCollection:
+    type: API_Collection
+    discriminatorValue: number
+    properties:
+      distributionDefaults: API_NumberDistributionDefaults
+      units: string
+      precision: number
+  API_NumberDistributionDefaults:
+    type: object
+    properties:
+      displayRangeMin?: number
+      displayRangeMax?: number
+      rangeMin?: number
+      rangeMax?: number
+      binWidth?: number
+      binWidthOverride?: number
+  API_NumberRangeFilter:
+    type: API_Filter
+    discriminatorValue: 'numberRange'
+    properties:
+      variableId: string
+      min: number
+      max: number
+  API_NumberSetFilter:
+    type: API_Filter
+    discriminatorValue: 'numberSet'
+    properties:
+      variableId: string
+      numberSet: number[]
+  API_NumberVariable:
+    type: API_VariableWithValues
+    discriminatorValue: number
+    properties:
+      distributionDefaults: API_NumberDistributionDefaults
+      units?: string
+      precision: number
+      scale?: API_VariableScale
+  API_PagingConfig:
+    type: object
+    properties:
+      numRows?:
+        type: integer
+        format: int64
+      offset?:
+        type: integer
+        format: int64
+  API_StringCollection:
+    type: API_Collection
+    discriminatorValue: string
+  API_StringSetFilter:
+    type: API_Filter
+    discriminatorValue: 'stringSet'
+    properties:
+      variableId: string
+      stringSet: string[]
+  API_StringVariable:
+    type: API_VariableWithValues
+    discriminatorValue: string
+  API_StudyDetail:
+    type: object
+    properties:
+      id: string
+      isUserStudy: boolean
+      hasMap: boolean
+      rootEntity: API_Entity
+  API_StudyOverview:
+    type: object
+    properties:
+      id: string
+      datasetId: string
+      sha1hash: string
+      sourceType: StudySourceType
+      displayName: string
+      shortDisplayName: string
+      lastModified: datetime
+      description: string
+  API_TabularReportConfig:
+    type: object
+    properties:
+      sorting?: SortSpecEntry[]
+      paging?: API_PagingConfig
+      headerFormat?: TabularHeaderFormat
+      trimTimeFromDateVars?: boolean
+      dataSource?: DataSourceType
+  API_Variable:
+    type: object
+    discriminator: type
+    properties:
+      id: string
+      parentId?: string
+      providerLabel: string
+      displayName: string
+      definition?: string
+      displayType: API_VariableDisplayType
+      displayOrder?:
+        type: integer
+        format: int64
+      isCategory: string
+      type: API_VariableType
+      hideFrom: string[]
+  API_VariableDataShape:
+    type: string
+    enum:
+      - continuous
+      - categorical
+      - ordinal
+      - binary
+  API_VariableDisplayType:
+    type: string
+    enum:
+      - default
+      - hidden
+      - multifilter
+      - geoaggregator
+      - latitude
+      - longitude
+  API_VariableScale:
+    type: string
+    enum:
+      - log
+      - log2
+      - ln
+  API_VariableType:
+    type: string
+    enum:
+      - category
+      - string
+      - number
+      - date
+      - longitude
+      - integer
+  API_VariableWithValues:
+    type: API_Variable
+    properties:
+      dataShape?: API_VariableDataShape
+      vocabulary?: string[]
+      distinctValuesCount:
+        type: integer
+        format: int64
+      isTemporal: boolean
+      isFeatured: boolean
+      isMergeKey: boolean
+      isMultiValued: boolean
+      imputeZero: boolean
+      hasStudyDependentVocabulary?: boolean
+      variableSpecToImputeZeroesFor?: VariableSpec
+  API_VariablesCategory:
+    type: API_Variable
+    discriminatorValue: category
+  AbundanceBoxplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: RankedAbundanceComputeConfig
+      config: BoxplotWith1ComputeSpec
+  AbundanceScatterplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: RankedAbundanceComputeConfig
+      config: ScatterplotWith1ComputeSpec
+  ActionList:
     type: object
     additionalProperties: false
     properties:
-      userId:
-        type: integer
-        format: int64
-        minimum: 1
-      firstName: string
-      lastName: string
-      organization: string
-      email: string
-  RestrictionLevel:
+      studyMetadata:
+        description: study metadata
+        type: boolean
+      subsetting:
+        description: count, distribution
+        type: boolean
+      visualizations:
+        description: all viz plugins
+        type: boolean
+      resultsFirstPage:
+        description: 'offset:0, numRecords: <=20'
+        type: boolean
+      resultsAll:
+        description: any other tabular response
+        type: boolean
+  AdvancedSubsetConfig:
+    type: object
+    properties:
+      rootStepKey: string
+      steps: Step[]
+  Aggregator:
     type: string
     enum:
-      - public
-      - prerelease
-      - protected
-      - controlled
-      - private
+      - mean
+      - median
+  AllBinRanges:
+    type: object
+    additionalProperties: false
+    properties:
+      equalInterval: LabeledRange[]
+      quantile: LabeledRange[]
+      standardDeviation: LabeledRange[]
+  AlphaDivBoxplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: AlphaDivComputeConfig
+      config: BoxplotWith1ComputeSpec
+  AlphaDivComputeConfig:
+    type: object
+    properties:
+      collectionVariable: CollectionSpec
+      alphaDivMethod: AlphaDivMethod
+  AlphaDivMethod:
+    type: string
+    enum:
+      - shannon
+      - simpson
+      - evenness
+  AlphaDivPluginRequest:
+    type: ComputeRequestBase
+    properties:
+      config: AlphaDivComputeConfig
+  AlphaDivScatterplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: AlphaDivComputeConfig
+      config: ScatterplotWith1ComputeSpec
+  AnalysisBase:
+    type: object
+    additionalProperties: false
+    properties:
+      displayName: string
+      description: string
+      studyId: string
+      studyVersion: string
+      apiVersion: string
+      isPublic: boolean
+  AnalysisDescriptor:
+    type: object
+    additionalProperties: false
+    properties:
+      subset:
+        type: object
+        properties:
+          descriptor: object[]
+          uiSettings?: object
+      computations: Computation[]
+      starredVariables: VariableSpec[]
+      dataTableConfig: DataTableConfigSet
+      derivedVariables: string[]
+  AnalysisDetail:
+    type: AnalysisSummary
+    additionalProperties: false
+    properties:
+      notes?: string
+      descriptor: AnalysisDescriptor
+  AnalysisListPatchRequest:
+    type: object
+    additionalProperties: false
+    properties:
+      analysisIdsToDelete?: string[]
+      inheritOwnershipFrom?:
+        type: integer
+        format: int64
+  AnalysisListPostRequest:
+    type: AnalysisBase
+    additionalProperties: false
+    properties:
+      notes?: string
+      descriptor: AnalysisDescriptor
+  AnalysisListPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      analysisId: string
+  AnalysisProvenance:
+    type: object
+    additionalProperties: false
+    properties:
+      onImport: OnImportProvenanceProps
+      current: CurrentProvenanceProps
+  AnalysisSummary:
+    type: AnalysisBase
+    additionalProperties: false
+    properties:
+      analysisId: string
+      creationTime: string
+      modificationTime: string
+      numFilters: integer
+      numComputations: integer
+      numVisualizations: integer
+      provenance?: AnalysisProvenance
+  AnalysisSummaryWithUser:
+    type: AnalysisSummary
+    additionalProperties: false
+    properties:
+      userId: number
+      userName: string
+      userOrganization: string
+  AppOverview:
+    type: object
+    additionalProperties: false
+    properties:
+      name: string
+      displayName: string
+      description: string
+      projects: string[]
+      computeName?: string
+      visualizations: VisualizationOverview[]
   ApprovalStatus:
     type: string
     enum:
@@ -38,6 +458,1129 @@ types:
       - approved
       - requested
       - denied
+  AppsGetResponse:
+    type: object
+    properties:
+      apps: AppOverview[]
+  Barplot:
+    type: object
+    additionalProperties: false
+    properties:
+      data: BarplotData[]
+      config: PlotConfig
+  BarplotData:
+    type: object
+    additionalProperties: false
+    properties:
+      overlayVariableDetails:
+        type: StrataVariableDetails
+        required: false
+      facetVariableDetails:
+        type: StrataVariableDetails[]
+        maxItems: 2
+        required: false
+      value:
+        type: number[]
+        minItems: 1
+      label:
+        type: string[]
+        minItems: 1
+  BarplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: BarplotSpec
+  BarplotPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      barplot: Barplot
+      sampleSizeTable: SampleSizeTable[]
+      completeCasesTable: VariableCompleteCases[]
+  BarplotSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      showMissingness:
+        type: ShowMissingnessNoAxes
+        required: false
+      barMode:
+        type: string
+        enum:
+          - group
+          - stack
+      valueSpec: ValueSpec
+      xAxisVariable: VariableSpec
+      overlayVariable:
+        type: VariableSpec
+        required: false
+      facetVariable:
+        type: VariableSpec[]
+        maxItems: 2
+        required: false
+  BaseCorrelationComputeConfig:
+    type: object
+    properties:
+      prefilterThresholds?: FeaturePrefilterThresholds
+  BaseMarker:
+    type: object
+    additionalProperties: false
+    properties:
+      geoAggregateValue: string
+      entityCount: number
+      avgLat: number
+      avgLon: number
+      minLat: number
+      minLon: number
+      maxLat: number
+      maxLon: number
+  BetaDivComputeConfig:
+    type: object
+    properties:
+      collectionVariable: CollectionSpec
+      betaDivDissimilarityMethod: BetaDivDissimilarityMethod
+  BetaDivDissimilarityMethod:
+    type: string
+    enum:
+      - bray
+      - jaccard
+      - jsd
+  BetaDivPluginRequest:
+    type: ComputeRequestBase
+    properties:
+      config: BetaDivComputeConfig
+  BetaDivScatterplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: BetaDivComputeConfig
+      config: BetaDivScatterplotSpec
+  BetaDivScatterplotSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      showMissingness:
+        type: ShowMissingnessNoAxes
+        required: false
+      overlayVariable:
+        type: VariableSpec
+        required: false
+      returnPointIds:
+        type: boolean
+        required: false
+  BetaDivStats:
+    type: object
+    properties:
+      pcoaVariance: number[]
+  BinSlider:
+    type: object
+    additionalProperties: false
+    properties:
+      min: number
+      max: number
+      step: number
+  BinSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      type?:
+        type: string
+        enum:
+          - binWidth
+          - numBins
+      value?: number
+      units?: BinUnits
+      range?: NumberRange | DateRange
+  BinSpecWithRange:
+    type: object
+    additionalProperties: false
+    properties:
+      displayRangeMin: any
+      displayRangeMax: any
+      binWidth: number
+      binUnits?: BinUnits
+  BinUnits:
+    type: string
+    enum:
+      - day
+      - week
+      - month
+      - year
+  BinWidthSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      type?:
+        type: string
+        enum:
+          - binWidth
+      value?: number
+      units?: BinUnits
+      range?: NumberRange | DateRange
+  BipartiteNetwork:
+    type: object
+    additionalProperties: false
+    properties:
+      data: BipartiteNetworkData
+      config: BipartiteNetworkConfig
+  BipartiteNetworkConfig:
+    type: NetworkConfig
+    properties:
+      partitionsMetadata:
+        type: string[]
+        minItems: 2
+        maxItems: 2
+  BipartiteNetworkData:
+    type: NetworkData
+    properties:
+      partitions:
+        type: NodeIdList[]
+        maxItems: 2
+        minItems: 2
+  BipartiteNetworkPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      bipartitenetwork: BipartiteNetwork
+  BodyMassIndexConfig:
+    type: object
+    properties:
+      heightVariable: VariableSpec
+      weightVariable: VariableSpec
+  Boxplot:
+    type: object
+    additionalProperties: false
+    properties:
+      data: BoxplotData[]
+      config: PlotConfig
+  BoxplotData:
+    type: object
+    additionalProperties: false
+    properties:
+      overlayVariableDetails:
+        type: StrataVariableDetails
+        required: false
+      facetVariableDetails:
+        type: StrataVariableDetails[]
+        maxItems: 2
+        required: false
+      lowerfence:
+        type: number[]
+        minItems: 1
+      upperfence:
+        type: number[]
+        minItems: 1
+      q1:
+        type: number[]
+        minItems: 1
+      q3:
+        type: number[]
+        minItems: 1
+      median:
+        type: number[]
+        minItems: 1
+      outliers:
+        type: number[][]
+        required: false
+      rawData:
+        type: number[][]
+        required: false
+      mean:
+        type: number[]
+        required: false
+      label: string[]
+  BoxplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: BoxplotSpec
+  BoxplotPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      boxplot: Boxplot
+      sampleSizeTable: SampleSizeTable[]
+      completeCasesTable: VariableCompleteCases[]
+      statsTable:
+        type: BoxplotStatsTable[]
+        required: false
+  BoxplotSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      showMissingness:
+        type: ShowMissingnessNoAxes
+        required: false
+      points:
+        type: string
+        enum:
+          - outliers
+          - all
+      mean: StringBoolean
+      computeStats: StringBoolean
+      xAxisVariable: VariableSpec
+      yAxisVariable: VariableSpec
+      overlayVariable:
+        type: VariableSpec
+        required: false
+      facetVariable:
+        type: VariableSpec[]
+        maxItems: 2
+        required: false
+      maxAllowedDataPoints:
+        type: integer
+        required: false
+        format: int64
+  BoxplotStatsTable:
+    type: object
+    additionalProperties: false
+    properties:
+      facetVariableDetails:
+        type: StrataVariableDetails[]
+        maxItems: 2
+        required: false
+      xVariableDetails:
+        type: StrataVariableDetails
+        required: false
+      statistic: string
+      pvalue: number
+      parameter: number[]
+      method: string
+      statsError: string
+  BoxplotWith1ComputeSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      showMissingness:
+        type: ShowMissingnessNoAxes
+        required: false
+      points:
+        type: string
+        enum:
+          - outliers
+          - all
+      mean: StringBoolean
+      computeStats: StringBoolean
+      xAxisVariable:
+        type: VariableSpec
+        required: false
+      overlayVariable:
+        type: VariableSpec
+        required: false
+      facetVariable:
+        type: VariableSpec[]
+        maxItems: 2
+        required: false
+  CategoricalAggregationConfig:
+    type: QuantitativeAggregationConfig
+    discriminatorValue: categorical
+    additionalProperties: false
+    properties:
+      numeratorValues: string[]
+      denominatorValues: string[]
+  CategoricalDistributionBin:
+    type: object
+    properties:
+      label: string
+      value: number
+  CategoricalDistributionPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: VariableSpec
+  CategoricalDistributionPostResponse:
+    type: object
+    properties:
+      countDistribution: CategoricalDistributionBin[]
+      proportionDistribution: CategoricalDistributionBin[]
+  CategoricalOverlayConfig:
+    type: OverlayConfig
+    discriminatorValue: categorical
+    additionalProperties: false
+    properties:
+      overlayValues:
+        type: string[]
+  CategoricalRecodingConfig:
+    type: object
+    properties:
+      inputVariable: VariableSpec
+      rules: CategoricalRecodingRule[]
+      unmappedValue?: string
+  CategoricalRecodingRule:
+    type: object
+    properties:
+      inputValues: string[]
+      outputValue: string
+  CollectionFloatingBarplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: CollectionFloatingBarplotSpec
+  CollectionFloatingBarplotSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      barMode:
+        type: string
+        enum:
+          - group
+          - stack
+      valueSpec: ValueSpec
+      overlayConfig: CollectionOverlayConfigWithValues
+  CollectionFloatingBoxplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: CollectionFloatingBoxplotSpec
+  CollectionFloatingBoxplotSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      xAxisVariable: VariableSpec
+      overlayConfig: CollectionOverlayConfig
+      maxAllowedDataPoints:
+        type: integer
+        required: false
+        format: int64
+  CollectionFloatingContTablePostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: CollectionFloatingContTableSpec
+  CollectionFloatingContTableSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      xAxisVariable: CollectionOverlayConfigWithValues
+  CollectionFloatingHistogramPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: CollectionFloatingHistogramSpec
+  CollectionFloatingHistogramSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      barMode:
+        type: string
+        enum:
+          - overlay
+          - stack
+      valueSpec: ValueSpec
+      overlayConfig: CollectionOverlayConfig
+      binSpec: BinWidthSpec
+      viewport:
+        type: NumericViewport
+        required: false
+  CollectionFloatingLineplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: CollectionFloatingLineplotSpec
+  CollectionFloatingLineplotSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      xAxisVariable: VariableSpec
+      yAxisNumeratorValues:
+        type: string[]
+        required: false
+      yAxisDenominatorValues:
+        type: string[]
+        required: false
+      overlayConfig: CollectionOverlayConfigWithValues
+      binSpec:
+        type: BinWidthSpec
+        required: false
+      valueSpec:
+        type: string
+        enum:
+          - median
+          - mean
+          - geometricMean
+          - proportion
+      errorBars: StringBoolean
+      viewport:
+        type: NumericViewport
+        required: false
+  CollectionMapMarkerElement:
+    description: |
+      Data needed to render a collection map marker. Contains geographical data as well as per-variable collection var
+      aggregates needed to render bar plots with error bar.
+    type: BaseMarker
+    properties:
+      overlayValues: CollectionMemberAggregate[]
+  CollectionMemberAggregate:
+    type: object
+    properties:
+      variableId: string
+      value: number
+      confidenceInterval: NumberRange
+      n: number
+  CollectionOverlayConfig:
+    description: |
+      Overlay configuration for the collection. Note that the variable IDs indicated must be members of the collection.
+    type: object
+    properties:
+      collection: CollectionSpec
+      selectedMembers: string[]
+  CollectionOverlayConfigWithValues:
+    type: CollectionOverlayConfig
+    properties:
+      selectedValues?: string[]
+  CollectionSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      entityId: string
+      collectionId: string
+  ColoredMapElementInfo:
+    type: BaseMarker
+    additionalProperties: false
+    properties:
+      overlayValue: string
+  ComparatorSpec:
+    type: object
+    properties:
+      variable: VariableSpec
+      groupA: LabeledRange[]
+      groupB: LabeledRange[]
+  Computation:
+    type: object
+    additionalProperties: false
+    properties:
+      computationId: string
+      displayName: string
+      descriptor: object
+      visualizations: Visualization[]
+  ComputeRequestBase:
+    type: object
+    properties:
+      studyId: string
+      filters:
+        type: array
+        required: false
+        items: API_Filter
+      derivedVariables:
+        type: array
+        items: DerivedVariableSpec
+  ComputeSpecForMerging:
+    type: object
+    additionalProperties: false
+    properties:
+      computeName: string
+      computeConfig: object
+  ComputedVariableMetadata:
+    type: object
+    additionalProperties: false
+    properties:
+      variables: VariableMapping[]
+  ConcatenationConfig:
+    type: object
+    properties:
+      prefix?: string
+      delimiter?: string
+      suffix?: string
+      inputVariables: VariableSpec[]
+  ContTablePostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      mosaic: Mosaic
+      sampleSizeTable: SampleSizeTable[]
+      statsTable:
+        type: ContTableStatsTable[]
+        required: false
+      completeCasesTable: VariableCompleteCases[]
+  ContTableStatsTable:
+    type: object
+    additionalProperties: false
+    properties:
+      facetVariableDetails:
+        type: StrataVariableDetails[]
+        maxItems: 2
+        required: false
+      pvalue:
+        type: number[]
+        minItems: 1
+      degreesFreedom:
+        type: number[]
+        minItems: 1
+      chisq:
+        type: number[]
+        minItems: 1
+  ContinousOverlayConfig:
+    type: OverlayConfig
+    additionalProperties: false
+    discriminatorValue: continuous
+    properties:
+      overlayValues:
+        type: LegacyLabeledRange[]
+  ContinuousAggregationConfig:
+    type: QuantitativeAggregationConfig
+    additionalProperties: false
+    discriminatorValue: continuous
+    properties:
+      aggregator: Aggregator
+  ContinuousNumericRecodingConfig:
+    type: object
+    properties:
+      inputVariable: VariableSpec
+      rules: ContinuousNumericRule[]
+      unmappedValue?: string
+  ContinuousNumericRule:
+    type: object
+    properties:
+      minInclusive?: number
+      maxExclusive?: number
+      outputValue: string
+  ContinuousVariableMetadataPostRequest:
+    type: DataPluginRequestBase
+    additionalProperties: false
+    properties:
+      config: ContinuousVariableMetadataSpec
+  ContinuousVariableMetadataPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      binRanges?: AllBinRanges
+      median?: number
+  ContinuousVariableMetadataSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      variable: VariableSpec
+      metadata:
+        type: array
+        items:
+          type: string
+          enum:
+            - binRanges
+            - median
+  CorrelationAssayAssayBipartitenetworkPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: CorrelationAssayAssayConfig
+      config: CorrelationNetworkSpec
+      # The Correlation Assay Metadata viz requires a collection as data1
+      # and metadata as data2. Note this is different than the standard CorrelationConfig
+  CorrelationAssayAssayConfig:
+    type: BaseCorrelationComputeConfig
+    properties:
+      correlationMethod: CorrelationMethod
+      data1: CorrelationInputDataCollection
+      data2: CorrelationInputDataCollection
+  CorrelationAssayMetadataBipartitenetworkPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: CorrelationAssayMetadataConfig
+      config: CorrelationNetworkSpec
+  CorrelationAssayMetadataConfig:
+    type: BaseCorrelationComputeConfig
+    properties:
+      correlationMethod: CorrelationMethod
+      data1: CorrelationInputDataCollection
+      data2: CorrelationInputDataMetadata
+  CorrelationBipartiteNetworkPostResponse:
+    type: BipartiteNetworkPostResponse
+    additionalProperties: false
+    properties:
+      significanceThreshold: number
+      correlationCoefThreshold: number
+  CorrelationBipartitenetworkPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: CorrelationConfig
+      config: CorrelationNetworkSpec
+  CorrelationConfig:
+    type: BaseCorrelationComputeConfig
+    properties:
+      correlationMethod: CorrelationMethod
+      data1: CorrelationInputData
+      data2: CorrelationInputData
+  CorrelationInputData:
+    type: object
+    properties:
+      dataType: CorrelationInputDataTypes
+      collectionSpec?: CollectionSpec
+  CorrelationInputDataCollection:
+    type: object
+    properties:
+      dataType:
+        type: string
+        enum:
+          - collection
+      collectionSpec: CollectionSpec
+  CorrelationInputDataMetadata:
+    type: object
+    properties:
+      dataType:
+        type: string
+        enum:
+          - metadata
+  CorrelationInputDataTypes:
+    type: string
+    enum:
+      - metadata
+      - collection
+  CorrelationMethod:
+    type: string
+    enum:
+      - spearman
+      - pearson
+  CorrelationNetworkPostResponse:
+    type: NetworkPostResponse
+    additionalProperties: false
+    properties:
+      significanceThreshold: number
+      correlationCoefThreshold: number
+  CorrelationNetworkSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      significanceThreshold:
+        type: number
+        required: false
+      correlationCoefThreshold:
+        type: number
+        required: false
+      layout?:
+        type: string
+        enum:
+          - none
+          - force
+          - circle
+          - nicely
+      degree: boolean
+      correlationDirection:
+        type: string
+        required: false
+        enum:
+          - both
+          - positive
+          - negative
+  CorrelationPluginRequest:
+    type: ComputeRequestBase
+    properties:
+      config: CorrelationConfig
+  CorrelationPoint:
+    type: object
+    properties:
+      data1: string
+      data2: string
+      correlationCoef:
+        type: string
+        required: false
+      pValue:
+        type: string
+        required: false
+      adjustedPValue:
+        type: string
+        required: false
+  CorrelationStatsResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      statistics: CorrelationPoint[]
+      data1Metadata: string
+      data2Metadata: string
+  CurrentProvenanceProps:
+    type: object
+    additionalProperties: false
+    properties:
+      isDeleted: boolean
+      modificationTime?: string
+      isPublic?: boolean
+  DataElementConstraint:
+    type: object
+    additionalProperties: false
+    properties:
+      isRequired: boolean
+      isTemporal: boolean
+      isCollection: boolean
+      isCompositional: boolean
+      isProportion: boolean
+      allowedNormalizationMethods: string[]
+      minNumVars: number
+      maxNumVars: number
+      minNumValues: number
+      maxNumValues: number
+      allowedTypes:
+        type: API_VariableType[]
+        required: false
+      allowedShapes:
+        type: API_VariableDataShape[]
+        required: false
+      description: string
+  DataElementConstraintPattern:
+    type: object
+    properties:
+      //: DataElementConstraint
+  DataPluginRequestBase:
+    type: object
+    additionalProperties: false
+    properties:
+      studyId: string
+      filters:
+        type: API_Filter[]
+        required: false
+      derivedVariables:
+        type: DerivedVariableSpec[]
+        required: false
+  DataSourceType:
+    type: string
+    enum:
+      - database
+      - file
+  DataTableConfig:
+    type: object
+    additionalProperties: false
+    properties:
+      variables: VariableSpec[]
+      sorting: SortSpecEntry[]
+  DataTableConfigSet:
+    type: object
+    properties:
+      //: DataTableConfig
+  DatasetPermissionEntry:
+    type: object
+    additionalProperties: false
+    properties:
+      studyId: string
+      sha1Hash: string
+      isUserStudy: boolean
+      displayName: string
+      shortDisplayName: string
+      description: string
+      type: DatasetPermissionLevel
+      actionAuthorization: ActionList
+      isManager?:
+        description: |
+          For providers, this field indicates whether the current user is marked
+          as a manager for the dataset represented by the containing permission
+          entry.
+
+          This field will only be present if the containing permission entry
+          type = `provider`.
+        type: boolean
+        default: false
+      accessRequestStatus: ApprovalStatus
+  DatasetPermissionLevel:
+    type: string
+    enum:
+      - provider
+      - end-user
+  DatasetProvider:
+    type: object
+    additionalProperties: false
+    properties:
+      providerId: DatastoreId
+      datasetId: string
+      user: UserDetails
+      isManager: boolean
+  DatasetProviderCreateRequest:
+    type: object
+    additionalProperties: false
+    properties:
+      datasetId: string
+      userId?:
+        type: integer
+        format: int64
+        minimum: 1
+      email?: string
+      isManager: boolean
+  DatasetProviderCreateResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      created:
+        description: |
+          Indicates whether a new provider record was created or not.
+
+          If this value is `false` the `"providerId"` property will not be set.
+          This happens when the request was sent using an email address that is
+          not in our user database.  In this case no provider record was created
+          but instead an email was sent to the given address requesting that the
+          user register.
+
+          If this value is `true` the `"providerId"` property will be set
+          containing the primary key value of the newly created provider record.
+        type: boolean
+      providerId?:
+        type: integer
+        format: int64
+        minimum: 1
+  DatasetProviderList:
+    type: object
+    additionalProperties: false
+    properties:
+      data: DatasetProvider[]
+      rows:
+        type: integer
+        format: int64
+        minimum: 0
+      offset:
+        type: integer
+        format: int64
+        minimum: 0
+      total:
+        type: integer
+        format: int64
+        minimum: 0
+  DatasetProviderPatch:
+    type: object
+    additionalProperties: false
+    properties:
+      op:
+        type: string
+        pattern: ^replace$
+      path:
+        type: string
+        pattern: ^/isManager$
+      value: boolean
+  DatasetProviderPatchRequest:
+    type: array
+    minItems: 1
+    maxItems: 1
+    items: DatasetProviderPatch
+  DatastoreId:
+    type: integer
+    format: int64
+    minimum: 1
+  DateRange:
+    type: object
+    additionalProperties: false
+    properties:
+      min: string
+      max: string
+  Densityplot:
+    type: object
+    additionalProperties: false
+    properties:
+      data: DensityplotData[]
+      config: PlotConfig
+  DensityplotData:
+    type: object
+    additionalProperties: false
+    properties:
+      overlayVariableDetails:
+        type: StrataVariableDetails
+        required: false
+      facetVariableDetails:
+        type: StrataVariableDetails[]
+        maxItems: 2
+        required: false
+      densityY:
+        type: number[]
+        minItems: 1
+      densityX:
+        type: number[]
+        minItems: 1
+  DensityplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: DensityplotSpec
+  DensityplotPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      densityplot: Densityplot
+      sampleSizeTable: SampleSizeTable[]
+      completeCasesTable: VariableCompleteCases[]
+  DensityplotSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      showMissingness:
+        type: ShowMissingnessNoAxes
+        required: false
+      xAxisVariable: VariableSpec
+      overlayVariable:
+        type: VariableSpec
+        required: false
+      facetVariable:
+        type: VariableSpec[]
+        maxItems: 2
+        required: false
+  DerivationType:
+    type: string
+    enum:
+      - transform
+      - reduction
+  DerivedVariableBulkMetadataRequest:
+    type: object
+    additionalProperties: false
+    properties:
+      studyId: string
+      derivedVariables: DerivedVariableSpec[]
+  DerivedVariableDocumentationRequest:
+    type: object
+    properties:
+      mean: SingleNumericVarReductionConfig
+      sum: SingleNumericVarReductionConfig
+      concatenation: ConcatenationConfig
+      subsetMembership: SubsetMembershipConfig
+      advancedSubset: AdvancedSubsetConfig
+      unitConversion: UnitConversionConfig
+      bodyMassIndex: BodyMassIndexConfig
+      categoricalRecoding: CategoricalRecodingConfig
+      continuousToOrdinal: ContinuousNumericRecodingConfig
+      ecmaScriptExpressionEval: EcmaScriptExpressionEvalConfig
+      relativeObservationMinTimeInterval: RelatedObservationMinTimeIntervalConfig
+  DerivedVariableGetResponse:
+    type: DerivedVariableSpec
+    additionalProperties: false
+    properties:
+      datasetId: string
+      description?:
+        type: string
+        minLength: 0
+        maxLength: 4000
+      provenance?: DerivedVariableProvenance
+  DerivedVariableMetadata:
+    type: VariableSpec
+    properties:
+      derivationType: DerivationType
+      variableType: API_VariableType
+      dataShape: API_VariableDataShape
+      vocabulary?: string[]
+      units?: string
+      dataRange?: Range
+      #precision: number
+      #binWidth?: number
+      #distinctValuesCount: integer
+      #isTemporal: boolean
+      #imputeZero: boolean
+  DerivedVariablePatchRequest:
+    type: object
+    additionalProperties: false
+    properties:
+      displayName?:
+        type: string
+        minLength: 1
+        maxLength: 256
+      description?:
+        type: string
+        maxLength: 4000
+  DerivedVariablePostRequest:
+    type: object
+    additionalProperties: false
+    properties:
+      datasetId: string
+      entityId: string
+      displayName:
+        type: string
+        minLength: 1
+        maxLength: 256
+      functionName: string
+      config: object
+      description?:
+        type: string
+        maxLength: 4000
+  DerivedVariablePostResponse:
+    type: VariableSpec
+    additionalProperties: false
+  DerivedVariableProvenance:
+    type: object
+    additionalProperties: false
+    properties:
+      copyDate: datetime-only
+      copiedFrom: string
+  DerivedVariableSpec:
+    type: VariableSpec
+    properties:
+      functionName: string
+      displayName: string
+      config: object # varies by plugin
+  DifferentialAbundanceComparatorSpec:
+    type: object
+    properties:
+      variable: VariableSpec
+      groupA: LabeledRange[]
+      groupB: LabeledRange[]
+  DifferentialAbundanceComputeConfig:
+    type: object
+    properties:
+      collectionVariable: CollectionSpec
+      comparator: DifferentialAbundanceComparatorSpec
+      differentialAbundanceMethod: DifferentialAbundanceMethod
+      pValueFloor:
+        type: string
+        required: false
+  DifferentialAbundanceMethod:
+    type: string
+    enum:
+      - DESeq
+      - ANCOMBC
+      - Maaslin
+  DifferentialAbundancePluginRequest:
+    type: ComputeRequestBase
+    properties:
+      config: DifferentialAbundanceComputeConfig
+  DifferentialAbundanceStats:
+    type: object
+    properties:
+      effectSize: string[]
+      pValue: string[]
+      adjustedPValue: string[]
+      pointId: string[]
+  DifferentialAbundanceStatsResponse:
+    type: object
+    properties:
+      effectSizeLabel: string
+      statistics: DifferentialAbundanceStats
+  DifferentialAbundanceVolcanoplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: DifferentialAbundanceComputeConfig
+      config: EmptyDataPluginSpec
+  DifferentialExpressionComputeConfig:
+    type: object
+    properties:
+      collectionVariable: CollectionSpec
+      comparator: ComparatorSpec
+      differentialExpressionMethod: DifferentialExpressionMethod
+      pValueFloor:
+        type: string
+        required: false
+  DifferentialExpressionMethod:
+    type: string
+    enum:
+      - DESeq
+  DifferentialExpressionPluginRequest:
+    type: ComputeRequestBase
+    properties:
+      config: DifferentialExpressionComputeConfig
+  DifferentialExpressionPoint:
+    type: object
+    properties:
+      effectSize: string
+      pValue: string
+      adjustedPValue: string
+      pointId: string
+  DifferentialExpressionStatsResponse:
+    type: object
+    properties:
+      effectSizeLabel: string
+      statistics: DifferentialExpressionPoint[]
+  DifferentialExpressionVolcanoplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      computeConfig: DifferentialExpressionComputeConfig
+      config: EmptyDataPluginSpec
+  DynamicDataSpec: CollectionSpec | VariableSpec
+  EcmaScriptExpressionEvalConfig:
+    type: object
+    properties:
+      ecmaScriptExpression: string
+      nullResultOnAnyMissingInput: boolean
+      inputVariables: VariableReference[]
+      expectedType: API_VariableType
+      expectedShape: API_VariableDataShape
+  EmptyDataPluginSpec:
+    type: object
+    additionalProperties: false
   EndUser:
     type: object
     additionalProperties: false
@@ -138,101 +1681,465 @@ types:
         pattern: ^/.+$
       value?: any
       from?: string
-  DatasetProvider:
+  EntityCountPostRequest:
     type: object
     additionalProperties: false
     properties:
-      providerId: DatastoreId
-      datasetId: string
-      user: UserDetails
-      isManager: boolean
-  DatasetProviderList:
+      filters: API_Filter[]
+  EntityCountPostResponse:
     type: object
     additionalProperties: false
     properties:
-      data: DatasetProvider[]
-      rows:
+      count:
         type: integer
         format: int64
-        minimum: 0
-      offset:
-        type: integer
-        format: int64
-        minimum: 0
-      total:
-        type: integer
-        format: int64
-        minimum: 0
-  DatasetProviderCreateRequest:
+  EntityIdGetResponse:
+    type: object
+    properties:
+      id: string
+      idColumnName: string
+      displayName: string
+      displayNamePlural: string
+      description: string
+      isManyToOneWithParent: boolean
+      variables: API_Variable[]
+      collections: API_Collection[]
+  EntityTabularPostRequest:
     type: object
     additionalProperties: false
     properties:
-      datasetId: string
-      userId?:
-        type: integer
-        format: int64
-        minimum: 1
-      email?: string
-      isManager: boolean
-  DatasetProviderCreateResponse:
+      filters: API_Filter[]
+      outputVariableIds: string[]
+      reportConfig?: API_TabularReportConfig
+  EntityTabularPostResponse:
     type: object
     additionalProperties: false
     properties:
-      created:
-        description: |
-          Indicates whether a new provider record was created or not.
-
-          If this value is `false` the `"providerId"` property will not be set.
-          This happens when the request was sent using an email address that is
-          not in our user database.  In this case no provider record was created
-          but instead an email was sent to the given address requesting that the
-          user register.
-
-          If this value is `true` the `"providerId"` property will be set
-          containing the primary key value of the newly created provider record.
-        type: boolean
-      providerId?:
-        type: integer
-        format: int64
-        minimum: 1
-  DatasetProviderPatchRequest:
-    type: array
-    minItems: 1
-    maxItems: 1
-    items: DatasetProviderPatch
-  DatasetProviderPatch:
+      tabular: string[][]
+  ErrorBar:
     type: object
     additionalProperties: false
     properties:
-      op:
+      lowerBound: number
+      upperBound: number
+      error: string
+  ExampleComputeConfig:
+    type: object
+    properties:
+      inputVariable: VariableSpec
+      valueSuffix: string
+      failureProbability: number
+  ExampleComputeVizPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: ExampleComputeVizSpec
+      computeConfig: ExampleComputeConfig
+  ExampleComputeVizPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      countPluginResult: integer
+      numEmptyValues: integer
+      longestConcatenatedValue: string
+      avgConcatenatedLength: number
+  ExampleComputeVizSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      prefixVar: VariableSpec
+  ExamplePluginRequest:
+    type: ComputeRequestBase
+    properties:
+      config: ExampleComputeConfig
+  ExamplePluginStats:
+    type: object
+    properties:
+      numEmptyValues: integer
+  ExpiredJobsResponse:
+    type: object
+    properties:
+      numJobsExpired: integer
+  FeaturePrefilterThresholds:
+    type: object
+    additionalProperties: false
+    properties:
+      proportionNonZero?: number
+      variance?: number
+      standardDeviation?: number
+  File:
+    type: object
+    additionalProperties: false
+    properties:
+      name: string
+      modifiedDate: string
+      size: string
+  FileContentResponse:
+    type: object
+    properties:
+      //: any
+  FloatingBarplot:
+    type: object
+    additionalProperties: false
+    properties:
+      data: BarplotData[]
+      variables: VariableMapping[]
+  FloatingBarplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: FloatingBarplotSpec
+  FloatingBarplotPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      barplot: FloatingBarplot
+  FloatingBarplotSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      barMode:
         type: string
-        pattern: ^replace$
-      path:
+        enum:
+          - group
+          - stack
+      valueSpec: ValueSpec
+      xAxisVariable: VariableSpec
+      overlayConfig?: OverlayConfig
+  FloatingBoxplot:
+    type: object
+    additionalProperties: false
+    properties:
+      data: BoxplotData[]
+      variables: VariableMapping[]
+  FloatingBoxplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: FloatingBoxplotSpec
+  FloatingBoxplotPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      boxplot: FloatingBoxplot
+  FloatingBoxplotSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      xAxisVariable: VariableSpec
+      yAxisVariable: VariableSpec
+      overlayConfig?: OverlayConfig
+      maxAllowedDataPoints:
+        type: integer
+        required: false
+        format: int64
+  FloatingContTable:
+    type: object
+    additionalProperties: false
+    properties:
+      data: MosaicData[]
+      variables: VariableMapping[]
+  FloatingContTablePostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: FloatingContTableSpec
+  FloatingContTablePostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      mosaic: FloatingContTable
+      statsTable:
+        type: TwoByTwoStatsTable[]
+        required: false
+  FloatingContTableSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      xAxisVariable: VariableSpec
+      yAxisVariable: VariableSpec
+  FloatingHistogram:
+    type: object
+    additionalProperties: false
+    properties:
+      data: HistogramData[]
+      variables: VariableMapping[]
+  FloatingHistogramPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: FloatingHistogramSpec
+  FloatingHistogramPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      histogram: FloatingHistogram
+  FloatingHistogramSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      xAxisVariable: VariableSpec
+      barMode:
         type: string
-        pattern: ^/isManager$
-      value: boolean
-  HistoryResponse:
+        enum:
+          - overlay
+          - stack
+      valueSpec: ValueSpec
+      overlayConfig?: OverlayConfig
+      binSpec: BinSpec
+      viewport:
+        type: NumericViewport
+        required: false
+  FloatingLineplot:
     type: object
     additionalProperties: false
     properties:
-      meta: HistoryMeta
-      results: HistoryResult[]
-  HistoryMeta:
+      data: LineplotData[]
+      variables: VariableMapping[]
+  FloatingLineplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: FloatingLineplotSpec
+  FloatingLineplotPostResponse:
     type: object
     additionalProperties: false
     properties:
-      rows:
+      lineplot: FloatingLineplot
+  FloatingLineplotSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      xAxisVariable: VariableSpec
+      yAxisVariable: VariableSpec
+      yAxisNumeratorValues:
+        type: string[]
+        required: false
+      yAxisDenominatorValues:
+        type: string[]
+        required: false
+      overlayConfig?: OverlayConfig
+      binSpec:
+        type: BinSpec
+        required: false
+      valueSpec:
+        type: string
+        enum:
+          - median
+          - mean
+          - geometricMean
+          - proportion
+      errorBars: StringBoolean
+      viewport:
+        type: NumericViewport
+        required: false
+  FloatingScatterplot:
+    type: object
+    additionalProperties: false
+    properties:
+      data: ScatterplotData[]
+      variables: VariableMapping[]
+  FloatingScatterplotPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: FloatingScatterplotSpec
+  FloatingScatterplotPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      scatterplot: FloatingScatterplot
+  FloatingScatterplotSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      valueSpec:
+        type: string
+        enum:
+          - raw
+          - smoothedMeanWithRaw
+          - bestFitLineWithRaw
+      xAxisVariable: VariableSpec
+      yAxisVariable: VariableSpec
+      overlayConfig?: OverlayConfig
+      maxAllowedDataPoints:
+        type: integer
+        required: false
+        format: int64
+  GeolocationViewport:
+    type: object
+    additionalProperties: false
+    properties:
+      latitude: NumericViewport
+      longitude: LongitudeViewport
+  Heatmap:
+    type: object
+    additionalProperties: false
+    properties:
+      data: HeatmapData[]
+      config: PlotConfig
+  HeatmapData:
+    type: object
+    additionalProperties: false
+    properties:
+      facetVariableDetails:
+        type: StrataVariableDetails[]
+        maxItems: 2
+        required: false
+      value:
+        type: number[][]
+        minItems: 1
+      label:
+        type: string[]
+        minItems: 1
+  HeatmapPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: HeatmapSpec
+  HeatmapPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      heatmap: Heatmap
+      sampleSizeTable: SampleSizeTable[]
+      completeCasesTable: VariableCompleteCases[]
+  HeatmapSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      showMissingness:
+        type: ShowMissingnessNoAxes
+        required: false
+      valueSpec:
+        type: string
+        enum:
+          - collection
+          - series
+      xAxisVariable: VariableSpec
+      yAxisVariable: VariableSpec
+      zAxisVariable:
+        type: VariableSpec
+        required: false
+      facetVariable:
+        type: VariableSpec[]
+        maxItems: 2
+        required: false
+  Histogram:
+    type: object
+    additionalProperties: false
+    properties:
+      data: HistogramData[]
+      config: HistogramConfig
+  HistogramBin:
+    type: object
+    additionalProperties: false
+    properties:
+      value: number
+      binStart: string
+      binEnd: string
+      binLabel: string
+  HistogramConfig:
+    type: PlotConfig
+    properties:
+      binSlider:
+        type: BinSlider
+      binSpec:
+        type: BinSpec
+      summary:
+        type: HistogramSummary
+      viewport:
+        type: NumericViewport
+  HistogramData:
+    type: object
+    additionalProperties: false
+    properties:
+      overlayVariableDetails:
+        type: StrataVariableDetails
+        required: false
+      facetVariableDetails:
+        type: StrataVariableDetails[]
+        maxItems: 2
+        required: false
+      value:
+        type: number[]
+        minItems: 1
+      binStart:
+        type: string[]
+        minItems: 1
+      binEnd:
+        type: string[]
+        minItems: 1
+      binLabel:
+        type: string[]
+        minItems: 1
+  HistogramPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: HistogramSpec
+  HistogramPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      histogram: Histogram
+      sampleSizeTable: SampleSizeTable[]
+      completeCasesTable: VariableCompleteCases[]
+  HistogramSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      showMissingness:
+        type: ShowMissingnessNoAxes
+        required: false
+      xAxisVariable: VariableSpec
+      barMode:
+        type: string
+        enum:
+          - overlay
+          - stack
+      valueSpec: ValueSpec
+      overlayVariable:
+        type: VariableSpec
+        required: false
+      facetVariable:
+        type: VariableSpec[]
+        maxItems: 2
+        required: false
+      binSpec: BinSpec
+      viewport:
+        type: NumericViewport
+        required: false
+  HistogramStats:
+    type: object
+    additionalProperties: false
+    properties:
+      subsetSize:
         type: integer
         format: int64
-      offset:
+      subsetMin?: any
+      subsetMax?: any
+      subsetMean?: any
+      numVarValues:
         type: integer
         format: int64
-  HistoryResult:
+      numDistinctValues:
+        type: integer
+        format: int64
+      numDistinctEntityRecords:
+        type: integer
+        format: int64
+      numMissingCases:
+        type: integer
+        format: int64
+  HistogramSummary:
     type: object
-    additionalProperties: false
     properties:
-      cause: HistoryCause
-      row: HistoryRow
+      min: string
+      q1: string
+      median: string
+      mean: string
+      q3: string
+      max: string
   HistoryCause:
     type: object
     additionalProperties: false
@@ -245,17 +2152,28 @@ types:
           - UPDATE
           - DELETE
       timestamp: datetime-only
-  HistoryUser:
+  HistoryMeta:
     type: object
     additionalProperties: false
     properties:
-      userID:
+      rows:
         type: integer
         format: int64
-      firstName: string
-      lastName: string
-      email: string
-      organization: string
+      offset:
+        type: integer
+        format: int64
+  HistoryResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      meta: HistoryMeta
+      results: HistoryResult[]
+  HistoryResult:
+    type: object
+    additionalProperties: false
+    properties:
+      cause: HistoryCause
+      row: HistoryRow
   HistoryRow:
     type: object
     additionalProperties: false
@@ -290,155 +2208,27 @@ types:
       denialReason: string
       dateDenied: datetime-only
       allowSelfEdits: boolean
-  PermissionsGetResponse:
+  HistoryUser:
     type: object
     additionalProperties: false
     properties:
-      isStaff?:
-        description: |
-          Indicates whether the current user is listed in the service's staff
-          entries.
-        type: boolean
-        default: false
-      isOwner?:
-        description: |
-          Indicates whether the current user is listed in the service's staff
-          entries _and_ is marked as a site owner.
-        type: boolean
-        default: false
-      perDataset?:
-        description: |
-          If the current user is a provider or an end user of one or more
-          datasets, these datasets will be listed here with the user's
-          permission level for each specific dataset.
-
-          If the user is not a provider or end user for any datasets, this field
-          will be omitted.
-        type: object
-        additionalProperties: false
-        properties:
-          //: DatasetPermissionEntry
-  ActionList:
-    type: object
-    additionalProperties: false
-    properties:
-      studyMetadata:
-        description: study metadata
-        type: boolean
-      subsetting:
-        description: count, distribution
-        type: boolean
-      visualizations:
-        description: all viz plugins
-        type: boolean
-      resultsFirstPage:
-        description: 'offset:0, numRecords: <=20'
-        type: boolean
-      resultsAll:
-        description: any other tabular response
-        type: boolean
-  StudyPermissionInfo:
-    type: object
-    additionalProperties: false
-    properties:
-      studyId: string
-      datasetId: string
-      isUserStudy: boolean
-      actionAuthorization: ActionList
-  DatasetPermissionEntry:
-    type: object
-    additionalProperties: false
-    properties:
-      studyId: string
-      sha1Hash: string
-      isUserStudy: boolean
-      displayName: string
-      shortDisplayName: string
-      description: string
-      type: DatasetPermissionLevel
-      actionAuthorization: ActionList
-      isManager?:
-        description: |
-          For providers, this field indicates whether the current user is marked
-          as a manager for the dataset represented by the containing permission
-          entry.
-
-          This field will only be present if the containing permission entry
-          type = `provider`.
-        type: boolean
-        default: false
-      accessRequestStatus: ApprovalStatus
-  DatasetPermissionLevel:
-    type: string
-    enum:
-      - provider
-      - end-user
-  Staff:
-    type: object
-    additionalProperties: false
-    properties:
-      staffId: DatastoreId
-      user: UserDetails
-      isOwner: boolean
-  StaffList:
-    type: object
-    additionalProperties: false
-    properties:
-      data: Staff[]
-      rows:
+      userID:
         type: integer
         format: int64
-        minimum: 0
-      offset:
-        type: integer
-        format: int64
-        minimum: 0
-      total:
-        type: integer
-        format: int64
-        minimum: 0
-  NewStaffRequest:
+      firstName: string
+      lastName: string
+      email: string
+      organization: string
+  InternalJob:
     type: object
     properties:
-      userId:
-        type: integer
-        format: int64
-        minimum: 1
-      isOwner: boolean
-  NewStaffResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      staffId:
-        type: integer
-        format: int64
-        minimum: 1
-  StaffPatchRequest:
-    type: array
-    minItems: 1
-    maxItems: 1
-    items: StaffPatch
-  StaffPatch:
-    type: object
-    additionalProperties: false
-    properties:
-      op:
-        type: string
-        pattern: ^replace$
-      path:
-        type: string
-        pattern: ^/isOwner$
-      value: boolean
+      jobId: JobID
+      status: JobStatus
+      owned: boolean
+      created: datetime
+      grabbed: datetime
+      finished: datetime
   JobID: !include https://raw.githubusercontent.com/VEuPathDB/lib-hash-id/v1.1.0/schema/hash-id.raml
-  JobStatus:
-    type: string
-    enum:
-      - no-such-job
-      - queued
-      - in-progress
-      - complete
-      - failed
-      - expired
   JobResponse:
     type: object
     additionalProperties: false
@@ -449,222 +2239,34 @@ types:
         type: integer
         required: false
         format: int32
-  ComputeRequestBase:
-    type: object
-    properties:
-      studyId: string
-      filters:
-        type: array
-        required: false
-        items: API_Filter
-      derivedVariables:
-        type: array
-        items: DerivedVariableSpec
-  VariableClass:
+  JobStatus:
     type: string
     enum:
-      - native
-      - derived
-      - computed
-  PlotReferenceValue:
-    type: string
-    enum:
-      - xAxis
-      - yAxis
-      - zAxis
-      - overlay
-      - facet1
-      - facet2
-      - geo
-      - latitude
-      - longitude
-  VariableMapping:
+      - no-such-job
+      - queued
+      - in-progress
+      - complete
+      - failed
+      - expired
+  KPartiteNetwork:
     type: object
     additionalProperties: false
     properties:
-      variableClass: VariableClass
-      variableSpec: VariableSpec
-      plotReference: PlotReferenceValue
-      dataType: API_VariableType
-      dataShape: API_VariableDataShape
-      displayName?: string
-      displayRangeMin?: any
-      displayRangeMax?: any
-      vocabulary?: string[]
-      imputeZero: boolean
-      hasStudyDependentVocabulary?: boolean
-      isCollection: boolean
-      members?: VariableSpec[]
-  ComputedVariableMetadata:
+      data: KPartiteNetworkData
+      config: KPartiteNetworkConfig
+  KPartiteNetworkConfig:
+    type: NetworkConfig
+    properties:
+      partitionsMetadata: string[]
+  KPartiteNetworkData:
+    type: NetworkData
+    properties:
+      partitions: NodeIdList[]
+  KPartiteNetworkPostResponse:
     type: object
     additionalProperties: false
     properties:
-      variables: VariableMapping[]
-  API_Filter:
-    type: object
-    discriminator: type
-    properties:
-      entityId: string
-      type: API_FilterType
-  API_FilterType:
-    type: string
-    enum:
-      - stringSet
-      - numberSet
-      - dateSet
-      - numberRange
-      - dateRange
-      - longitudeRange
-      - multiFilter
-  API_BooleanOperationType:
-    type: string
-    enum:
-      - intersect
-      - union
-  API_MultiFilterSubFilter:
-    type: object
-    properties:
-      variableId: string
-      stringSet: string[]
-  API_MultiFilter:
-    type: API_Filter
-    discriminatorValue: 'multiFilter'
-    properties:
-      operation: API_BooleanOperationType
-      variableId: string
-      subFilters: API_MultiFilterSubFilter[]
-  API_StringSetFilter:
-    type: API_Filter
-    discriminatorValue: 'stringSet'
-    properties:
-      variableId: string
-      stringSet: string[]
-  API_NumberSetFilter:
-    type: API_Filter
-    discriminatorValue: 'numberSet'
-    properties:
-      variableId: string
-      numberSet: number[]
-  API_DateSetFilter:
-    type: API_Filter
-    discriminatorValue: 'dateSet'
-    properties:
-      variableId: string
-      dateSet: string[] # how to constrain this to a date?
-  API_NumberRangeFilter:
-    type: API_Filter
-    discriminatorValue: 'numberRange'
-    properties:
-      variableId: string
-      min: number
-      max: number
-  API_DateRangeFilter:
-    type: API_Filter
-    discriminatorValue: 'dateRange'
-    properties:
-      variableId: string
-      min: string
-      max: string
-  API_LongitudeRangeFilter:
-    type: API_Filter
-    discriminatorValue: 'longitudeRange'
-    properties:
-      variableId: string
-      left: number
-      right: number
-  DerivedVariableSpec:
-    type: VariableSpec
-    properties:
-      functionName: string
-      displayName: string
-      config: object # varies by plugin
-  ComputeSpecForMerging:
-    type: object
-    additionalProperties: false
-    properties:
-      computeName: string
-      computeConfig: object
-  DerivedVariableBulkMetadataRequest:
-    type: object
-    additionalProperties: false
-    properties:
-      studyId: string
-      derivedVariables: DerivedVariableSpec[]
-  MergedEntityTabularPostRequest:
-    type: DerivedVariableBulkMetadataRequest
-    additionalProperties: false
-    properties:
-      filters: API_Filter[]
-      entityId: string
-      outputVariables: VariableSpec[]
-      computeSpec?: ComputeSpecForMerging
-  DerivationType:
-    type: string
-    enum:
-      - transform
-      - reduction
-  DerivedVariableMetadata:
-    type: VariableSpec
-    properties:
-      derivationType: DerivationType
-      variableType: API_VariableType
-      dataShape: API_VariableDataShape
-      vocabulary?: string[]
-      units?: string
-      dataRange?: Range
-      #precision: number
-      #binWidth?: number
-      #distinctValuesCount: integer
-      #isTemporal: boolean
-      #imputeZero: boolean
-  VariableSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      entityId: string
-      variableId: string
-  CollectionSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      entityId: string
-      collectionId: string
-  DataElementConstraint:
-    type: object
-    additionalProperties: false
-    properties:
-      isRequired: boolean
-      isTemporal: boolean
-      isCollection: boolean
-      isCompositional: boolean
-      isProportion: boolean
-      allowedNormalizationMethods: string[]
-      minNumVars: number
-      maxNumVars: number
-      minNumValues: number
-      maxNumValues: number
-      allowedTypes:
-        type: API_VariableType[]
-        required: false
-      allowedShapes:
-        type: API_VariableDataShape[]
-        required: false
-      description: string
-  DataElementConstraintPattern:
-    type: object
-    properties:
-      //: DataElementConstraint
-  EntityTabularPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      tabular: string[][]
-  Range:
-    type: object
-    additionalProperties: false
-    properties:
-      min: string
-      max: string
+      kpartitenetwork: KPartiteNetwork
   LabeledRange:
     type: Range
     additionalProperties: false
@@ -675,1120 +2277,78 @@ types:
     additionalProperties: false
     properties:
       value: number
-  StudiesGetResponse:
+  LegacyLabeledRange:
     type: object
     additionalProperties: false
     properties:
-      studies: API_StudyOverview[]
-  StudyIdGetResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      study: API_StudyDetail
-  StudySourceType:
-    type: string
-    enum:
-      - curated
-      - user_submitted
-  API_StudyOverview:
-    type: object
-    properties:
-      id: string
-      datasetId: string
-      sha1hash: string
-      sourceType: StudySourceType
-      displayName: string
-      shortDisplayName: string
-      lastModified: datetime
-      description: string
-  EntityIdGetResponse:
-    type: object
-    properties:
-      id: string
-      idColumnName: string
-      displayName: string
-      displayNamePlural: string
-      description: string
-      isManyToOneWithParent: boolean
-      variables: API_Variable[]
-      collections: API_Collection[]
-  API_StudyDetail:
-    type: object
-    properties:
-      id: string
-      isUserStudy: boolean
-      hasMap: boolean
-      rootEntity: API_Entity
-  API_Entity:
-    type: EntityIdGetResponse
-    properties:
-      children?: API_Entity[]
-  API_Collection:
-    type: object
-    discriminator: type
-    properties:
-      id: string
-      displayName: string
-      type: API_CollectionType
-      dataShape: API_VariableDataShape
-      vocabulary?: string[]
-      distinctValuesCount?:
-        type: integer
-        format: int64
-      memberVariableIds: string[]
-      imputeZero: boolean
-      normalizationMethod: string
-      isCompositional: boolean
-      isProportion: boolean
-      variableSpecToImputeZeroesFor?: VariableSpec
-      member: string
-      memberPlural: string
-  API_CollectionType:
-    type: string
-    enum:
-      - number
-      - date
-      - integer
-      - string
-  API_NumberCollection:
-    type: API_Collection
-    discriminatorValue: number
-    properties:
-      distributionDefaults: API_NumberDistributionDefaults
-      units: string
-      precision: number
-  API_IntegerCollection:
-    type: API_Collection
-    discriminatorValue: integer
-    properties:
-      distributionDefaults: API_IntegerDistributionDefaults
-      units: string
-  API_DateCollection:
-    type: API_Collection
-    discriminatorValue: date
-    properties:
-      distributionDefaults: API_DateDistributionDefaults
-  API_StringCollection:
-    type: API_Collection
-    discriminatorValue: string
-  API_Variable:
-    type: object
-    discriminator: type
-    properties:
-      id: string
-      parentId?: string
-      providerLabel: string
-      displayName: string
-      definition?: string
-      displayType: API_VariableDisplayType
-      displayOrder?:
-        type: integer
-        format: int64
-      isCategory: string
-      type: API_VariableType
-      hideFrom: string[]
-  API_VariableWithValues:
-    type: API_Variable
-    properties:
-      dataShape?: API_VariableDataShape
-      vocabulary?: string[]
-      distinctValuesCount:
-        type: integer
-        format: int64
-      isTemporal: boolean
-      isFeatured: boolean
-      isMergeKey: boolean
-      isMultiValued: boolean
-      imputeZero: boolean
-      hasStudyDependentVocabulary?: boolean
-      variableSpecToImputeZeroesFor?: VariableSpec
-  API_VariableType:
-    type: string
-    enum:
-      - category
-      - string
-      - number
-      - date
-      - longitude
-      - integer
-  API_VariableDataShape:
-    type: string
-    enum:
-      - continuous
-      - categorical
-      - ordinal
-      - binary
-  API_VariableDisplayType:
-    type: string
-    enum:
-      - default
-      - hidden
-      - multifilter
-      - geoaggregator
-      - latitude
-      - longitude
-  API_VariableScale:
-    type: string
-    enum:
-      - log
-      - log2
-      - ln
-  API_VariablesCategory:
-    type: API_Variable
-    discriminatorValue: category
-  API_StringVariable:
-    type: API_VariableWithValues
-    discriminatorValue: string
-  API_LongitudeVariable:
-    type: API_VariableWithValues
-    discriminatorValue: longitude
-    properties:
-      precision: number
-  API_NumberDistributionDefaults:
-    type: object
-    properties:
-      displayRangeMin?: number
-      displayRangeMax?: number
-      rangeMin?: number
-      rangeMax?: number
-      binWidth?: number
-      binWidthOverride?: number
-  API_IntegerDistributionDefaults:
-    type: object
-    properties:
-      displayRangeMin?:
-        type: integer
-        format: int64
-      displayRangeMax?:
-        type: integer
-        format: int64
-      rangeMin?:
-        type: integer
-        format: int64
-      rangeMax?:
-        type: integer
-        format: int64
-      binWidth?:
-        type: integer
-        format: int64
-      binWidthOverride?:
-        type: integer
-        format: int64
-  API_DateDistributionDefaults:
-    type: object
-    properties:
-      displayRangeMin?: string
-      displayRangeMax?: string
-      rangeMin?: string
-      rangeMax?: string
-      binWidth?: integer
-      binWidthOverride?: integer
-      binUnits?: BinUnits
-  API_NumberVariable:
-    type: API_VariableWithValues
-    discriminatorValue: number
-    properties:
-      distributionDefaults: API_NumberDistributionDefaults
-      units?: string
-      precision: number
-      scale?: API_VariableScale
-  API_IntegerVariable:
-    type: API_VariableWithValues
-    discriminatorValue: integer
-    properties:
-      distributionDefaults: API_IntegerDistributionDefaults
-      units?: string
-  API_DateVariable:
-    type: API_VariableWithValues
-    discriminatorValue: date
-    properties:
-      distributionDefaults: API_DateDistributionDefaults
-  EntityCountPostRequest:
-    type: object
-    additionalProperties: false
-    properties:
-      filters: API_Filter[]
-  EntityCountPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      count:
-        type: integer
-        format: int64
-  SortDirection:
-    type: string
-    enum:
-      - asc
-      - desc
-  SortSpecEntry:
-    type: object
-    additionalProperties: false
-    properties:
-      key: string
-      direction: SortDirection
-  API_PagingConfig:
-    type: object
-    properties:
-      numRows?:
-        type: integer
-        format: int64
-      offset?:
-        type: integer
-        format: int64
-  TabularHeaderFormat:
-    type: string
-    enum:
-      - standard
-      - display
-  DataSourceType:
-    type: string
-    enum:
-      - database
-      - file
-  API_TabularReportConfig:
-    type: object
-    properties:
-      sorting?: SortSpecEntry[]
-      paging?: API_PagingConfig
-      headerFormat?: TabularHeaderFormat
-      trimTimeFromDateVars?: boolean
-      dataSource?: DataSourceType
-  EntityTabularPostRequest:
-    type: object
-    additionalProperties: false
-    properties:
-      filters: API_Filter[]
-      outputVariableIds: string[]
-      reportConfig?: API_TabularReportConfig
-  BinUnits:
-    type: string
-    enum:
-      - day
-      - week
-      - month
-      - year
-  BinSpecWithRange:
-    type: object
-    additionalProperties: false
-    properties:
-      displayRangeMin: any
-      displayRangeMax: any
-      binWidth: number
-      binUnits?: BinUnits
-  ValueSpec:
-    type: string
-    enum:
-      - count
-      - proportion
-  VariableDistributionPostRequest:
-    type: object
-    additionalProperties: false
-    properties:
-      filters: API_Filter[]
-      binSpec?: BinSpecWithRange
-      valueSpec: ValueSpec
-  VocabByRootEntityPostRequest:
-    type: object
-    additionalProperties: false
-    properties:
-      filters: API_Filter[]
-  VocabByRootEntityPostResponse:
-    type: EntityTabularPostResponse
-    additionalProperties: false
-  HistogramBin:
-    type: object
-    additionalProperties: false
-    properties:
-      value: number
       binStart: string
       binEnd: string
       binLabel: string
-  HistogramStats:
+  LegacyLabeledRangeWithCountAndValue:
+    type: LegacyLabeledRange
+    additionalProperties: false
+    properties:
+      value: number
+      count: number
+  Lineplot:
     type: object
     additionalProperties: false
     properties:
-      subsetSize:
-        type: integer
-        format: int64
-      subsetMin?: any
-      subsetMax?: any
-      subsetMean?: any
-      numVarValues:
-        type: integer
-        format: int64
-      numDistinctValues:
-        type: integer
-        format: int64
-      numDistinctEntityRecords:
-        type: integer
-        format: int64
-      numMissingCases:
-        type: integer
-        format: int64
-  VariableDistributionPostResponse:
+      data: LineplotData[]
+      config: LineplotConfig
+  LineplotConfig:
+    type: PlotConfig
+    properties:
+      binSlider?:
+        type: BinSlider
+      binSpec?:
+        type: BinSpec
+      viewport?:
+        type: NumericViewport
+  LineplotData:
     type: object
     additionalProperties: false
     properties:
-      histogram: HistogramBin[]
-      statistics: HistogramStats
-  AlphaDivPluginRequest:
-    type: ComputeRequestBase
-    properties:
-      config: AlphaDivComputeConfig
-  AlphaDivComputeConfig:
-    type: object
-    properties:
-      collectionVariable: CollectionSpec
-      alphaDivMethod: AlphaDivMethod
-  AlphaDivMethod:
-    type: string
-    enum:
-      - shannon
-      - simpson
-      - evenness
-  BetaDivPluginRequest:
-    type: ComputeRequestBase
-    properties:
-      config: BetaDivComputeConfig
-  BetaDivComputeConfig:
-    type: object
-    properties:
-      collectionVariable: CollectionSpec
-      betaDivDissimilarityMethod: BetaDivDissimilarityMethod
-  BetaDivDissimilarityMethod:
-    type: string
-    enum:
-      - bray
-      - jaccard
-      - jsd
-  BetaDivStats:
-    type: object
-    properties:
-      pcoaVariance: number[]
-  CorrelationMethod:
-    type: string
-    enum:
-      - spearman
-      - pearson
-  SelfCorrelationMethod:
-    type: string
-    enum:
-      - spearman
-      - pearson
-      - sparcc
-  FeaturePrefilterThresholds:
-    type: object
-    additionalProperties: false
-    properties:
-      proportionNonZero?: number
-      variance?: number
-      standardDeviation?: number
-  BaseCorrelationComputeConfig:
-    type: object
-    properties:
-      prefilterThresholds?: FeaturePrefilterThresholds
-  CorrelationInputDataTypes:
-    type: string
-    enum:
-      - metadata
-      - collection
-  CorrelationInputData:
-    type: object
-    properties:
-      dataType: CorrelationInputDataTypes
-      collectionSpec?: CollectionSpec
-  CorrelationConfig:
-    type: BaseCorrelationComputeConfig
-    properties:
-      correlationMethod: CorrelationMethod
-      data1: CorrelationInputData
-      data2: CorrelationInputData
-  CorrelationPluginRequest:
-    type: ComputeRequestBase
-    properties:
-      config: CorrelationConfig
-  SelfCorrelationConfig:
-    type: BaseCorrelationComputeConfig
-    properties:
-      correlationMethod: SelfCorrelationMethod
-      data1: CollectionSpec #someday if we do metadata X metadata, make this CorrelationInputData
-  SelfCorrelationPluginRequest:
-    type: ComputeRequestBase
-    properties:
-      config: SelfCorrelationConfig
-  CorrelationStatsResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      statistics: CorrelationPoint[]
-      data1Metadata: string
-      data2Metadata: string
-  CorrelationPoint:
-    type: object
-    properties:
-      data1: string
-      data2: string
-      correlationCoef:
-        type: string
+      overlayVariableDetails:
+        type: StrataVariableDetails
         required: false
-      pValue:
-        type: string
-        required: false
-      adjustedPValue:
-        type: string
-        required: false
-  DifferentialAbundancePluginRequest:
-    type: ComputeRequestBase
-    properties:
-      config: DifferentialAbundanceComputeConfig
-  DifferentialAbundanceComputeConfig:
-    type: object
-    properties:
-      collectionVariable: CollectionSpec
-      comparator: DifferentialAbundanceComparatorSpec
-      differentialAbundanceMethod: DifferentialAbundanceMethod
-      pValueFloor:
-        type: string
-        required: false
-  DifferentialAbundanceMethod:
-    type: string
-    enum:
-      - DESeq
-      - ANCOMBC
-      - Maaslin
-  DifferentialAbundanceComparatorSpec:
-    type: object
-    properties:
-      variable: VariableSpec
-      groupA: LabeledRange[]
-      groupB: LabeledRange[]
-  DifferentialAbundanceStats:
-    type: object
-    properties:
-      effectSize: string[]
-      pValue: string[]
-      adjustedPValue: string[]
-      pointId: string[]
-  DifferentialAbundanceStatsResponse:
-    type: object
-    properties:
-      effectSizeLabel: string
-      statistics: DifferentialAbundanceStats
-  DifferentialExpressionPluginRequest:
-    type: ComputeRequestBase
-    properties:
-      config: DifferentialExpressionComputeConfig
-  DifferentialExpressionComputeConfig:
-    type: object
-    properties:
-      collectionVariable: CollectionSpec
-      comparator: ComparatorSpec
-      differentialExpressionMethod: DifferentialExpressionMethod
-      pValueFloor:
-        type: string
-        required: false
-  DifferentialExpressionMethod:
-    type: string
-    enum:
-      - DESeq
-  ComparatorSpec:
-    type: object
-    properties:
-      variable: VariableSpec
-      groupA: LabeledRange[]
-      groupB: LabeledRange[]
-  DifferentialExpressionPoint:
-    type: object
-    properties:
-      effectSize: string
-      pValue: string
-      adjustedPValue: string
-      pointId: string
-  DifferentialExpressionStatsResponse:
-    type: object
-    properties:
-      effectSizeLabel: string
-      statistics: DifferentialExpressionPoint[]
-  ExamplePluginRequest:
-    type: ComputeRequestBase
-    properties:
-      config: ExampleComputeConfig
-  ExampleComputeConfig:
-    type: object
-    properties:
-      inputVariable: VariableSpec
-      valueSuffix: string
-      failureProbability: number
-  ExamplePluginStats:
-    type: object
-    properties:
-      numEmptyValues: integer
-  RankedAbundancePluginRequest:
-    type: ComputeRequestBase
-    properties:
-      config: RankedAbundanceComputeConfig
-  RankedAbundanceComputeConfig:
-    type: object
-    properties:
-      collectionVariable: CollectionSpec
-      rankingMethod: RankingMethod
-  RankingMethod:
-    type: string
-    enum:
-      - median
-      - q3
-      - variance
-      - max
-  RankedAbundanceStats:
-    type: object
-    additionalProperties: false
-    properties:
-      isCutoff: boolean
-  InternalJob:
-    type: object
-    properties:
-      jobId: JobID
-      status: JobStatus
-      owned: boolean
-      created: datetime
-      grabbed: datetime
-      finished: datetime
-  PluginOverview:
-    displayName: Plugin Overview
-    type: object
-    additionalProperties: false
-    properties:
-      name: string
-      displayName: string
-      description: string
-      dataElementConstraints?: DataElementConstraintPattern[]
-  ExpiredJobsResponse:
-    type: object
-    properties:
-      numJobsExpired: integer
-  AbundanceBoxplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      computeConfig: RankedAbundanceComputeConfig
-      config: BoxplotWith1ComputeSpec
-  AbundanceScatterplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      computeConfig: RankedAbundanceComputeConfig
-      config: ScatterplotWith1ComputeSpec
-  AlphaDivBoxplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      computeConfig: AlphaDivComputeConfig
-      config: BoxplotWith1ComputeSpec
-  AlphaDivScatterplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      computeConfig: AlphaDivComputeConfig
-      config: ScatterplotWith1ComputeSpec
-  AppsGetResponse:
-    type: object
-    properties:
-      apps: AppOverview[]
-  AppOverview:
-    type: object
-    additionalProperties: false
-    properties:
-      name: string
-      displayName: string
-      description: string
-      projects: string[]
-      computeName?: string
-      visualizations: VisualizationOverview[]
-  VisualizationOverview:
-    type: object
-    additionalProperties: false
-    properties:
-      name: string
-      displayName: string
-      description: string
-      projects: string[]
-      maxPanels: number
-      dataElementConstraints:
-        type: DataElementConstraintPattern[]
-        required: false
-      dataElementDependencyOrder:
-        type: string[][]
-        required: false
-  BetaDivScatterplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      computeConfig: BetaDivComputeConfig
-      config: BetaDivScatterplotSpec
-  BetaDivScatterplotSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      showMissingness:
-        type: ShowMissingnessNoAxes
-        required: false
-      overlayVariable:
-        type: VariableSpec
-        required: false
-      returnPointIds:
-        type: boolean
-        required: false
-  CorrelationNetworkSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      significanceThreshold:
-        type: number
-        required: false
-      correlationCoefThreshold:
-        type: number
-        required: false
-      layout?:
-        type: string
-        enum:
-          - none
-          - force
-          - circle
-          - nicely
-      degree: boolean
-  CorrelationBipartiteNetworkPostResponse:
-    type: BipartiteNetworkPostResponse
-    additionalProperties: false
-    properties:
-      significanceThreshold: number
-      correlationCoefThreshold: number
-  CorrelationBipartitenetworkPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      computeConfig: CorrelationConfig
-      config: CorrelationNetworkSpec
-  CorrelationInputDataCollection:
-    type: object
-    properties:
-      dataType:
-        type: string
-        enum:
-          - collection
-      collectionSpec: CollectionSpec
-  CorrelationInputDataMetadata:
-    type: object
-    properties:
-      dataType:
-        type: string
-        enum:
-          - metadata
-  CorrelationAssayAssayConfig:
-    type: BaseCorrelationComputeConfig
-    properties:
-      correlationMethod: CorrelationMethod
-      data1: CorrelationInputDataCollection
-      data2: CorrelationInputDataCollection
-  CorrelationAssayAssayBipartitenetworkPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      computeConfig: CorrelationAssayAssayConfig
-      config: CorrelationNetworkSpec
-      # The Correlation Assay Metadata viz requires a collection as data1
-      # and metadata as data2. Note this is different than the standard CorrelationConfig
-  CorrelationAssayMetadataConfig:
-    type: BaseCorrelationComputeConfig
-    properties:
-      correlationMethod: CorrelationMethod
-      data1: CorrelationInputDataCollection
-      data2: CorrelationInputDataMetadata
-  CorrelationAssayMetadataBipartitenetworkPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      computeConfig: CorrelationAssayMetadataConfig
-      config: CorrelationNetworkSpec
-  SelfCorrelationUnipartitenetworkPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      computeConfig: SelfCorrelationConfig
-      config: CorrelationNetworkSpec
-  CorrelationNetworkPostResponse:
-    type: NetworkPostResponse
-    additionalProperties: false
-    properties:
-      significanceThreshold: number
-      correlationCoefThreshold: number
-  DifferentialAbundanceVolcanoplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      computeConfig: DifferentialAbundanceComputeConfig
-      config: EmptyDataPluginSpec
-  DifferentialExpressionVolcanoplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      computeConfig: DifferentialExpressionComputeConfig
-      config: EmptyDataPluginSpec
-  ContinuousVariableMetadataPostRequest:
-    type: DataPluginRequestBase
-    additionalProperties: false
-    properties:
-      config: ContinuousVariableMetadataSpec
-  ContinuousVariableMetadataSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      variable: VariableSpec
-      metadata:
-        type: array
-        items:
-          type: string
-          enum:
-            - binRanges
-            - median
-  AllBinRanges:
-    type: object
-    additionalProperties: false
-    properties:
-      equalInterval: LabeledRange[]
-      quantile: LabeledRange[]
-      standardDeviation: LabeledRange[]
-  ContinuousVariableMetadataPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      binRanges?: AllBinRanges
-      median?: number
-  NodeData:
-    type: object
-    properties:
-      id: string
-      degree?: number
-  LinkData:
-    type: object
-    properties:
-      source: NodeData
-      target: NodeData
-      weight: string
-      color: string
-  NetworkData:
-    type: object
-    properties:
-      nodes: NodeData[]
-      links: LinkData[]
-  NetworkConfig:
-    type: object
-    properties:
-      variables:
-        type: VariableMapping[]
-        required: false
-  KPartiteNetworkConfig:
-    type: NetworkConfig
-    properties:
-      partitionsMetadata: string[]
-  NodeIdList:
-    type: object
-    additionalProperties: false
-    properties:
-      nodeIds: string[]
-  KPartiteNetworkData:
-    type: NetworkData
-    properties:
-      partitions: NodeIdList[]
-  KPartiteNetwork:
-    type: object
-    additionalProperties: false
-    properties:
-      data: KPartiteNetworkData
-      config: KPartiteNetworkConfig
-  KPartiteNetworkPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      kpartitenetwork: KPartiteNetwork
-  BipartiteNetworkConfig:
-    type: NetworkConfig
-    properties:
-      partitionsMetadata:
-        type: string[]
-        minItems: 2
-        maxItems: 2
-  BipartiteNetworkData:
-    type: NetworkData
-    properties:
-      partitions:
-        type: NodeIdList[]
-        maxItems: 2
-        minItems: 2
-  BipartiteNetwork:
-    type: object
-    additionalProperties: false
-    properties:
-      data: BipartiteNetworkData
-      config: BipartiteNetworkConfig
-  BipartiteNetworkPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      bipartitenetwork: BipartiteNetwork
-  Network:
-    type: object
-    additionalProperties: false
-    properties:
-      data: NetworkData
-      config: NetworkConfig
-  NetworkPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      network: Network
-  BarplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: BarplotSpec
-  BarplotSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      showMissingness:
-        type: ShowMissingnessNoAxes
-        required: false
-      barMode:
-        type: string
-        enum:
-          - group
-          - stack
-      valueSpec: ValueSpec
-      xAxisVariable: VariableSpec
-      overlayVariable:
-        type: VariableSpec
-        required: false
-      facetVariable:
-        type: VariableSpec[]
-        maxItems: 2
-        required: false
-  Barplot:
-    type: object
-    additionalProperties: false
-    properties:
-      data: BarplotData[]
-      config: PlotConfig
-  BarplotPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      barplot: Barplot
-      sampleSizeTable: SampleSizeTable[]
-      completeCasesTable: VariableCompleteCases[]
-  BoxplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: BoxplotSpec
-  BoxplotSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      showMissingness:
-        type: ShowMissingnessNoAxes
-        required: false
-      points:
-        type: string
-        enum:
-          - outliers
-          - all
-      mean: StringBoolean
-      computeStats: StringBoolean
-      xAxisVariable: VariableSpec
-      yAxisVariable: VariableSpec
-      overlayVariable:
-        type: VariableSpec
-        required: false
-      facetVariable:
-        type: VariableSpec[]
-        maxItems: 2
-        required: false
-      maxAllowedDataPoints:
-        type: integer
-        required: false
-        format: int64
-  Boxplot:
-    type: object
-    additionalProperties: false
-    properties:
-      data: BoxplotData[]
-      config: PlotConfig
-  BoxplotPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      boxplot: Boxplot
-      sampleSizeTable: SampleSizeTable[]
-      completeCasesTable: VariableCompleteCases[]
-      statsTable:
-        type: BoxplotStatsTable[]
-        required: false
-  ContTableStatsTable:
-    type: object
-    additionalProperties: false
-    properties:
       facetVariableDetails:
         type: StrataVariableDetails[]
         maxItems: 2
         required: false
-      pvalue:
-        type: number[]
+      seriesY:
+        type: string[]
         minItems: 1
-      degreesFreedom:
-        type: number[]
+      seriesX:
+        type: string[]
         minItems: 1
-      chisq:
-        type: number[]
+      binStart:
+        type: string[]
         minItems: 1
-  ContTablePostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      mosaic: Mosaic
-      sampleSizeTable: SampleSizeTable[]
-      statsTable:
-        type: ContTableStatsTable[]
         required: false
-      completeCasesTable: VariableCompleteCases[]
-  DensityplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: DensityplotSpec
-  DensityplotSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      showMissingness:
-        type: ShowMissingnessNoAxes
+      binEnd:
+        type: string[]
+        minItems: 1
         required: false
-      xAxisVariable: VariableSpec
-      overlayVariable:
-        type: VariableSpec
+      binSampleSize:
+        type: SampleSize[]
+        minItems: 1
         required: false
-      facetVariable:
-        type: VariableSpec[]
-        maxItems: 2
+      errorBars:
+        type: ErrorBar[]
+        minItems: 1
         required: false
-  Densityplot:
-    type: object
-    additionalProperties: false
-    properties:
-      data: DensityplotData[]
-      config: PlotConfig
-  DensityplotPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      densityplot: Densityplot
-      sampleSizeTable: SampleSizeTable[]
-      completeCasesTable: VariableCompleteCases[]
-  HeatmapPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: HeatmapSpec
-  HeatmapSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      showMissingness:
-        type: ShowMissingnessNoAxes
-        required: false
-      valueSpec:
-        type: string
-        enum:
-          - collection
-          - series
-      xAxisVariable: VariableSpec
-      yAxisVariable: VariableSpec
-      zAxisVariable:
-        type: VariableSpec
-        required: false
-      facetVariable:
-        type: VariableSpec[]
-        maxItems: 2
-        required: false
-  Heatmap:
-    type: object
-    additionalProperties: false
-    properties:
-      data: HeatmapData[]
-      config: PlotConfig
-  HeatmapPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      heatmap: Heatmap
-      sampleSizeTable: SampleSizeTable[]
-      completeCasesTable: VariableCompleteCases[]
-  HistogramPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: HistogramSpec
-  HistogramSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      showMissingness:
-        type: ShowMissingnessNoAxes
-        required: false
-      xAxisVariable: VariableSpec
-      barMode:
-        type: string
-        enum:
-          - overlay
-          - stack
-      valueSpec: ValueSpec
-      overlayVariable:
-        type: VariableSpec
-        required: false
-      facetVariable:
-        type: VariableSpec[]
-        maxItems: 2
-        required: false
-      binSpec: BinSpec
-      viewport:
-        type: NumericViewport
-        required: false
-  HistogramSummary:
-    type: object
-    properties:
-      min: string
-      q1: string
-      median: string
-      mean: string
-      q3: string
-      max: string
-  HistogramConfig:
-    type: PlotConfig
-    properties:
-      binSlider:
-        type: BinSlider
-      binSpec:
-        type: BinSpec
-      summary:
-        type: HistogramSummary
-      viewport:
-        type: NumericViewport
-  Histogram:
-    type: object
-    additionalProperties: false
-    properties:
-      data: HistogramData[]
-      config: HistogramConfig
-  HistogramPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      histogram: Histogram
-      sampleSizeTable: SampleSizeTable[]
-      completeCasesTable: VariableCompleteCases[]
   LineplotPostRequest:
     type: DataPluginRequestBase
     properties:
       config: LineplotSpec
+  LineplotPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      lineplot: Lineplot
+      sampleSizeTable: SampleSizeTable[]
+      completeCasesTable: VariableCompleteCases[]
   LineplotSpec:
     type: object
     additionalProperties: false
@@ -1826,88 +2386,24 @@ types:
       viewport:
         type: NumericViewport
         required: false
-  LineplotConfig:
-    type: PlotConfig
+  LinkData:
+    type: object
     properties:
-      binSlider?:
-        type: BinSlider
-      binSpec?:
-        type: BinSpec
-      viewport?:
-        type: NumericViewport
-  Lineplot:
+      source: NodeData
+      target: NodeData
+      weight: string
+      color: string
+  LongitudeViewport:
     type: object
     additionalProperties: false
     properties:
-      data: LineplotData[]
-      config: LineplotConfig
-  LineplotPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      lineplot: Lineplot
-      sampleSizeTable: SampleSizeTable[]
-      completeCasesTable: VariableCompleteCases[]
-  MapMarkersOverlayPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: MapMarkersOverlaySpec
-  MapMarkersOverlaySpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      showMissingness:
-        type: ShowMissingness
-        required: false
-      xAxisVariable: VariableSpec
-      geoAggregateVariable: VariableSpec
-      valueSpec: ValueSpec
-      longitudeVariable?: VariableSpec
-      latitudeVariable?: VariableSpec
-      viewport?: GeolocationViewport
-  MapMarkersOverlayConfig:
-    type: PlotConfig
-    properties:
-      viewport:
-        type: GeolocationViewport
-  MapMarkersOverlay:
-    type: object
-    additionalProperties: false
-    properties:
-      data: MapMarkersOverlayData[]
-      config: MapMarkersOverlayConfig
-  MapMarkersOverlayPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      mapMarkers: MapMarkersOverlay
-      sampleSizeTable: SampleSizeTable[]
-      completeCasesTable: VariableCompleteCases[]
-  MapPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: MapSpec
-  MapSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      geoAggregateVariable: VariableSpec
-      longitudeVariable: VariableSpec
-      latitudeVariable: VariableSpec
-      viewport: GeolocationViewport
+      left: number
+      right: number
   MapConfig:
     type: object
     additionalProperties: false
     properties:
       completeCasesGeoVar: number
-  MapPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      mapElements: MapElementInfo[]
-      config: MapConfig
   MapElementInfo:
     type: object
     additionalProperties: false
@@ -1920,139 +2416,17 @@ types:
       minLon: number
       maxLat: number
       maxLon: number
-  ScatterplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: ScatterplotSpec
-  ScatterCorrelationMethod:
-    type: string
-    enum:
-      - none
-      - spearman
-      - pearson
-      - sparcc
-  ScatterplotSpec:
+  MapMarkersOverlay:
     type: object
     additionalProperties: false
     properties:
-      outputEntityId: string
-      showMissingness:
-        type: ShowMissingnessNoAxes
-        required: false
-      valueSpec:
-        type: string
-        enum:
-          - raw
-          - smoothedMeanWithRaw
-          - bestFitLineWithRaw
-      xAxisVariable: VariableSpec
-      yAxisVariable: VariableSpec
-      overlayVariable:
-        type: VariableSpec
-        required: false
-      facetVariable:
-        type: VariableSpec[]
-        maxItems: 2
-        required: false
-      maxAllowedDataPoints:
-        type: integer
-        required: false
-        format: int64
-      correlationMethod: ScatterCorrelationMethod
-      returnPointIds:
-        type: boolean
-        required: false
-  Scatterplot:
-    type: object
-    additionalProperties: false
+      data: MapMarkersOverlayData[]
+      config: MapMarkersOverlayConfig
+  MapMarkersOverlayConfig:
+    type: PlotConfig
     properties:
-      data: ScatterplotData[]
-      config: PlotConfig
-  ScatterplotPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      scatterplot: Scatterplot
-      sampleSizeTable: SampleSizeTable[]
-      completeCasesTable: VariableCompleteCases[]
-  TablePostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: TableSpec
-  TableSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      outputVariable: VariableSpec[]
-      pagingConfig: API_PagingConfig
-  TablePostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      columns: VariableSpec[]
-      rows: string[][]
-  TwoByTwoSpec:
-    type: MosaicSpec
-    properties:
-      xAxisReferenceValue: string
-      yAxisReferenceValue: string
-  TwoByTwoPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: TwoByTwoSpec
-  Statistic:
-    type: object
-    additionalProperties: false
-    properties:
-      value: number
-      confidenceInterval?: string
-      confidenceLevel?: number
-      pvalue: string
-  TwoByTwoStatsTable:
-    type: object
-    additionalProperties: false
-    properties:
-      facetVariableDetails:
-        type: StrataVariableDetails[]
-        maxItems: 2
-        required: false
-      chisq: Statistic
-      fisher: Statistic
-      prevalence?: Statistic
-      oddsratio?: Statistic
-      relativerisk?: Statistic
-      sensitivity?: Statistic
-      specificity?: Statistic
-      posPredictiveValue?: Statistic
-      negPredictiveValue?: Statistic
-  TwoByTwoPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      mosaic: Mosaic
-      sampleSizeTable: SampleSizeTable[]
-      statsTable:
-        type: TwoByTwoStatsTable[]
-        required: false
-      completeCasesTable: VariableCompleteCases[]
-  BarplotData:
-    type: object
-    additionalProperties: false
-    properties:
-      overlayVariableDetails:
-        type: StrataVariableDetails
-        required: false
-      facetVariableDetails:
-        type: StrataVariableDetails[]
-        maxItems: 2
-        required: false
-      value:
-        type: number[]
-        minItems: 1
-      label:
-        type: string[]
-        minItems: 1
+      viewport:
+        type: GeolocationViewport
   MapMarkersOverlayData:
     type: object
     additionalProperties: false
@@ -2067,101 +2441,85 @@ types:
       label:
         type: string[]
         minItems: 1
-  BoxplotData:
+  MapMarkersOverlayPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: MapMarkersOverlaySpec
+  MapMarkersOverlayPostResponse:
     type: object
     additionalProperties: false
     properties:
-      overlayVariableDetails:
-        type: StrataVariableDetails
+      mapMarkers: MapMarkersOverlay
+      sampleSizeTable: SampleSizeTable[]
+      completeCasesTable: VariableCompleteCases[]
+  MapMarkersOverlaySpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      showMissingness:
+        type: ShowMissingness
         required: false
+      xAxisVariable: VariableSpec
+      geoAggregateVariable: VariableSpec
+      valueSpec: ValueSpec
+      longitudeVariable?: VariableSpec
+      latitudeVariable?: VariableSpec
+      viewport?: GeolocationViewport
+  MapPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: MapSpec
+  MapPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      mapElements: MapElementInfo[]
+      config: MapConfig
+  MapSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      geoAggregateVariable: VariableSpec
+      longitudeVariable: VariableSpec
+      latitudeVariable: VariableSpec
+      viewport: GeolocationViewport
+  MergedEntityTabularPostRequest:
+    type: DerivedVariableBulkMetadataRequest
+    additionalProperties: false
+    properties:
+      filters: API_Filter[]
+      entityId: string
+      outputVariables: VariableSpec[]
+      computeSpec?: ComputeSpecForMerging
+  MetricsReportResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      count: integer
+  Mosaic:
+    type: object
+    additionalProperties: false
+    properties:
+      data: MosaicData[]
+      config: PlotConfig
+  MosaicData:
+    type: object
+    additionalProperties: false
+    properties:
       facetVariableDetails:
         type: StrataVariableDetails[]
         maxItems: 2
         required: false
-      lowerfence:
-        type: number[]
-        minItems: 1
-      upperfence:
-        type: number[]
-        minItems: 1
-      q1:
-        type: number[]
-        minItems: 1
-      q3:
-        type: number[]
-        minItems: 1
-      median:
-        type: number[]
-        minItems: 1
-      outliers:
-        type: number[][]
-        required: false
-      rawData:
-        type: number[][]
-        required: false
-      mean:
-        type: number[]
-        required: false
-      label: string[]
-  BoxplotStatsTable:
-    type: object
-    additionalProperties: false
-    properties:
-      facetVariableDetails:
-        type: StrataVariableDetails[]
-        maxItems: 2
-        required: false
-      xVariableDetails:
-        type: StrataVariableDetails
-        required: false
-      statistic: string
-      pvalue: number
-      parameter: number[]
-      method: string
-      statsError: string
-  HistogramData:
-    type: object
-    additionalProperties: false
-    properties:
-      overlayVariableDetails:
-        type: StrataVariableDetails
-        required: false
-      facetVariableDetails:
-        type: StrataVariableDetails[]
-        maxItems: 2
-        required: false
-      value:
-        type: number[]
-        minItems: 1
-      binStart:
+      xLabel:
         type: string[]
         minItems: 1
-      binEnd:
-        type: string[]
+      yLabel:
+        type: string[][]
         minItems: 1
-      binLabel:
-        type: string[]
-        minItems: 1
-  BinSlider:
-    type: object
-    additionalProperties: false
-    properties:
-      min: number
-      max: number
-      step: number
-  HeatmapData:
-    type: object
-    additionalProperties: false
-    properties:
-      facetVariableDetails:
-        type: StrataVariableDetails[]
-        maxItems: 2
-        required: false
       value:
         type: number[][]
-        minItems: 1
-      label:
-        type: string[]
         minItems: 1
   MosaicPostRequest:
     type: DataPluginRequestBase
@@ -2181,28 +2539,270 @@ types:
         type: VariableSpec[]
         maxItems: 2
         required: false
-  MosaicData:
+  MultiStreamPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: MultiStreamSpec
+  MultiStreamSpec:
     type: object
     additionalProperties: false
     properties:
+      entityId: string
+  Network:
+    type: object
+    additionalProperties: false
+    properties:
+      data: NetworkData
+      config: NetworkConfig
+  NetworkConfig:
+    type: object
+    properties:
+      variables:
+        type: VariableMapping[]
+        required: false
+  NetworkData:
+    type: object
+    properties:
+      nodes: NodeData[]
+      links: LinkData[]
+  NetworkPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      network: Network
+  NewStaffRequest:
+    type: object
+    properties:
+      userId:
+        type: integer
+        format: int64
+        minimum: 1
+      isOwner: boolean
+  NewStaffResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      staffId:
+        type: integer
+        format: int64
+        minimum: 1
+  NodeData:
+    type: object
+    properties:
+      id: string
+      degree?: number
+  NodeIdList:
+    type: object
+    additionalProperties: false
+    properties:
+      nodeIds: string[]
+  NumberRange:
+    type: object
+    additionalProperties: false
+    properties:
+      min: number
+      max: number
+  NumericViewport:
+    type: object
+    additionalProperties: false
+    properties:
+      xMin: string
+      xMax: string
+  OnImportProvenanceProps:
+    type: object
+    additionalProperties: false
+    properties:
+      ownerId:
+        type: integer
+        format: int64
+      ownerName: string
+      ownerOrganization: string
+      analysisId: string
+      analysisName: string
+      creationTime: string
+      modificationTime: string
+      isPublic: boolean
+  OverlayConfig:
+    type: object
+    additionalProperties: false
+    discriminator: overlayType
+    properties:
+      overlayType: OverlayType
+      overlayVariable: VariableSpec
+  OverlayLegendConfig:
+    type: object
+    additionalProperties: false
+    properties:
+      geoAggregateVariable: VariableSpec
+      quantitativeOverlayConfig: QuantitativeOverlayConfig
+  OverlayType:
+    type: string
+    enum:
+      - continuous
+      - categorical
+  PermissionsGetResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      isStaff?:
+        description: |
+          Indicates whether the current user is listed in the service's staff
+          entries.
+        type: boolean
+        default: false
+      isOwner?:
+        description: |
+          Indicates whether the current user is listed in the service's staff
+          entries _and_ is marked as a site owner.
+        type: boolean
+        default: false
+      perDataset?:
+        description: |
+          If the current user is a provider or an end user of one or more
+          datasets, these datasets will be listed here with the user's
+          permission level for each specific dataset.
+
+          If the user is not a provider or end user for any datasets, this field
+          will be omitted.
+        type: object
+        additionalProperties: false
+        properties:
+          //: DatasetPermissionEntry
+  PlotConfig:
+    type: object
+    additionalProperties: false
+    properties:
+      completeCasesAllVars: number
+      completeCasesAxesVars: number
+      variables: VariableMapping[]
+  PlotReferenceValue:
+    type: string
+    enum:
+      - xAxis
+      - yAxis
+      - zAxis
+      - overlay
+      - facet1
+      - facet2
+      - geo
+      - latitude
+      - longitude
+  PluginOverview:
+    displayName: Plugin Overview
+    type: object
+    additionalProperties: false
+    properties:
+      name: string
+      displayName: string
+      description: string
+      dataElementConstraints?: DataElementConstraintPattern[]
+  ProportionSampleSize:
+    type: object
+    additionalProperties: false
+    properties:
+      numeratorN: number
+      denominatorN: number
+  QuantitativeAggregationConfig:
+    type: object
+    additionalProperties: false
+    discriminator: overlayType
+    properties:
+      overlayType: OverlayType
+  QuantitativeOverlayConfig:
+    type: object
+    properties:
+      overlayVariable: VariableSpec
+      aggregationConfig: QuantitativeAggregationConfig
+  Range:
+    type: object
+    additionalProperties: false
+    properties:
+      min: string
+      max: string
+  RankedAbundanceComputeConfig:
+    type: object
+    properties:
+      collectionVariable: CollectionSpec
+      rankingMethod: RankingMethod
+  RankedAbundancePluginRequest:
+    type: ComputeRequestBase
+    properties:
+      config: RankedAbundanceComputeConfig
+  RankedAbundanceStats:
+    type: object
+    additionalProperties: false
+    properties:
+      isCutoff: boolean
+  RankingMethod:
+    type: string
+    enum:
+      - median
+      - q3
+      - variance
+      - max
+  RecordCountPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: RecordCountSpec
+  RecordCountPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      recordCount: integer
+  RecordCountSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      entityId: string
+  RelatedObservationMinTimeIntervalConfig:
+    type: object
+    properties:
+      relatedObservationsSubset: API_Filter[]
+      anchorVariable: VariableSpec
+      anchorVariableTrueValues: string[]
+      anchorTimestampVariable: VariableSpec
+      targetVariable: VariableSpec
+      targetVariableTrueValues: string[]
+      targetTimestampVariable: VariableSpec
+      minimumTimeIntervalDays: integer
+  RestrictionLevel:
+    type: string
+    enum:
+      - public
+      - prerelease
+      - protected
+      - controlled
+      - private
+  SampleSize: SimpleSampleSize | ProportionSampleSize
+  SampleSizeTable:
+    type: object
+    additionalProperties: false
+    properties:
+      xVariableDetails:
+        type: StrataVariableDetails[]
+        required: false
+      overlayVariableDetails:
+        type: StrataVariableDetails
+        required: false
       facetVariableDetails:
         type: StrataVariableDetails[]
         maxItems: 2
         required: false
-      xLabel:
-        type: string[]
+      size:
+        type: number[]
         minItems: 1
-      yLabel:
-        type: string[][]
-        minItems: 1
-      value:
-        type: number[][]
-        minItems: 1
-  Mosaic:
+  ScatterCorrelationMethod:
+    type: string
+    enum:
+      - none
+      - spearman
+      - pearson
+      - sparcc
+  Scatterplot:
     type: object
     additionalProperties: false
     properties:
-      data: MosaicData[]
+      data: ScatterplotData[]
       config: PlotConfig
   ScatterplotData:
     type: object
@@ -2245,469 +2845,25 @@ types:
       pointIds:
         type: string[]
         required: false
-  DensityplotData:
-    type: object
-    additionalProperties: false
-    properties:
-      overlayVariableDetails:
-        type: StrataVariableDetails
-        required: false
-      facetVariableDetails:
-        type: StrataVariableDetails[]
-        maxItems: 2
-        required: false
-      densityY:
-        type: number[]
-        minItems: 1
-      densityX:
-        type: number[]
-        minItems: 1
-  LineplotData:
-    type: object
-    additionalProperties: false
-    properties:
-      overlayVariableDetails:
-        type: StrataVariableDetails
-        required: false
-      facetVariableDetails:
-        type: StrataVariableDetails[]
-        maxItems: 2
-        required: false
-      seriesY:
-        type: string[]
-        minItems: 1
-      seriesX:
-        type: string[]
-        minItems: 1
-      binStart:
-        type: string[]
-        minItems: 1
-        required: false
-      binEnd:
-        type: string[]
-        minItems: 1
-        required: false
-      binSampleSize:
-        type: SampleSize[]
-        minItems: 1
-        required: false
-      errorBars:
-        type: ErrorBar[]
-        minItems: 1
-        required: false
-  PlotConfig:
-    type: object
-    additionalProperties: false
-    properties:
-      completeCasesAllVars: number
-      completeCasesAxesVars: number
-      variables: VariableMapping[]
-  SampleSizeTable:
-    type: object
-    additionalProperties: false
-    properties:
-      xVariableDetails:
-        type: StrataVariableDetails[]
-        required: false
-      overlayVariableDetails:
-        type: StrataVariableDetails
-        required: false
-      facetVariableDetails:
-        type: StrataVariableDetails[]
-        maxItems: 2
-        required: false
-      size:
-        type: number[]
-        minItems: 1
-  VariableCompleteCases:
-    type: object
-    additionalProperties: false
-    properties:
-      variableDetails: VariableSpec
-      completeCases: number
-  CategoricalDistributionPostRequest:
+  ScatterplotPostRequest:
     type: DataPluginRequestBase
     properties:
-      config: VariableSpec
-  CategoricalDistributionBin:
-    type: object
-    properties:
-      label: string
-      value: number
-  CategoricalDistributionPostResponse:
-    type: object
-    properties:
-      countDistribution: CategoricalDistributionBin[]
-      proportionDistribution: CategoricalDistributionBin[]
-  ExampleComputeVizPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: ExampleComputeVizSpec
-      computeConfig: ExampleComputeConfig
-  ExampleComputeVizSpec:
+      config: ScatterplotSpec
+  ScatterplotPostResponse:
     type: object
     additionalProperties: false
     properties:
-      prefixVar: VariableSpec
-  ExampleComputeVizPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      countPluginResult: integer
-      numEmptyValues: integer
-      longestConcatenatedValue: string
-      avgConcatenatedLength: number
-  MultiStreamPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: MultiStreamSpec
-  MultiStreamSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      entityId: string
-  RecordCountPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: RecordCountSpec
-  RecordCountSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      entityId: string
-  RecordCountPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      recordCount: integer
-  TestCollectionsPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: CollectionSpec
-  BaseMarker:
-    type: object
-    additionalProperties: false
-    properties:
-      geoAggregateValue: string
-      entityCount: number
-      avgLat: number
-      avgLon: number
-      minLat: number
-      minLon: number
-      maxLat: number
-      maxLon: number
-  CollectionFloatingBarplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: CollectionFloatingBarplotSpec
-  CollectionFloatingBarplotSpec:
+      scatterplot: Scatterplot
+      sampleSizeTable: SampleSizeTable[]
+      completeCasesTable: VariableCompleteCases[]
+  ScatterplotSpec:
     type: object
     additionalProperties: false
     properties:
       outputEntityId: string
-      barMode:
-        type: string
-        enum:
-          - group
-          - stack
-      valueSpec: ValueSpec
-      overlayConfig: CollectionOverlayConfigWithValues
-  CollectionFloatingBoxplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: CollectionFloatingBoxplotSpec
-  CollectionFloatingBoxplotSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      xAxisVariable: VariableSpec
-      overlayConfig: CollectionOverlayConfig
-      maxAllowedDataPoints:
-        type: integer
+      showMissingness:
+        type: ShowMissingnessNoAxes
         required: false
-        format: int64
-  CollectionFloatingContTablePostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: CollectionFloatingContTableSpec
-  CollectionFloatingContTableSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      xAxisVariable: CollectionOverlayConfigWithValues
-  CollectionFloatingHistogramPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: CollectionFloatingHistogramSpec
-  CollectionFloatingHistogramSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      barMode:
-        type: string
-        enum:
-          - overlay
-          - stack
-      valueSpec: ValueSpec
-      overlayConfig: CollectionOverlayConfig
-      binSpec: BinWidthSpec
-      viewport:
-        type: NumericViewport
-        required: false
-  CollectionFloatingLineplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: CollectionFloatingLineplotSpec
-  CollectionFloatingLineplotSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      xAxisVariable: VariableSpec
-      yAxisNumeratorValues:
-        type: string[]
-        required: false
-      yAxisDenominatorValues:
-        type: string[]
-        required: false
-      overlayConfig: CollectionOverlayConfigWithValues
-      binSpec:
-        type: BinWidthSpec
-        required: false
-      valueSpec:
-        type: string
-        enum:
-          - median
-          - mean
-          - geometricMean
-          - proportion
-      errorBars: StringBoolean
-      viewport:
-        type: NumericViewport
-        required: false
-  StandaloneCollectionMapMarkerPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: StandaloneCollectionMapMarkerSpec
-  StandaloneCollectionMapMarkerSpec:
-    description: Specification for a collection-level map marker visualization.
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId:
-        description: Entity ID associated with collection variable of interest.
-        type: string
-      geoAggregateVariable:
-        description: Geohash component variable to group markers by. This is usually determined by zoom level of the client application.
-        type: VariableSpec
-      longitudeVariable:
-        description: Variable representing longitude of output entity.
-        type: VariableSpec
-      latitudeVariable:
-        description: Variable representing latitude of output entity.
-        type: VariableSpec
-      viewport:
-        description: Viewport used to filter markers. Only entities that are contained in the viewport will be grouped into markers.
-        type: GeolocationViewport
-      collectionOverlay:
-        description: Collection variable to use for markers.
-        type: CollectionOverlayConfig
-      aggregatorConfig:
-        description: Specification for how variable values will be aggregated into quantiative value shown in bar plot marker.
-        type: QuantitativeAggregationConfig
-  CollectionOverlayConfig:
-    description: |
-      Overlay configuration for the collection. Note that the variable IDs indicated must be members of the collection.
-    type: object
-    properties:
-      collection: CollectionSpec
-      selectedMembers: string[]
-  CollectionMapMarkerElement:
-    description: |
-      Data needed to render a collection map marker. Contains geographical data as well as per-variable collection var
-      aggregates needed to render bar plots with error bar.
-    type: BaseMarker
-    properties:
-      overlayValues: CollectionMemberAggregate[]
-  CollectionMemberAggregate:
-    type: object
-    properties:
-      variableId: string
-      value: number
-      confidenceInterval: NumberRange
-      n: number
-  StandaloneCollectionMapMarkerPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      markers: CollectionMapMarkerElement[]
-  FloatingBarplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: FloatingBarplotSpec
-  FloatingBarplotSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      barMode:
-        type: string
-        enum:
-          - group
-          - stack
-      valueSpec: ValueSpec
-      xAxisVariable: VariableSpec
-      overlayConfig?: OverlayConfig
-  FloatingBarplot:
-    type: object
-    additionalProperties: false
-    properties:
-      data: BarplotData[]
-      variables: VariableMapping[]
-  FloatingBarplotPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      barplot: FloatingBarplot
-  FloatingBoxplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: FloatingBoxplotSpec
-  FloatingBoxplotSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      xAxisVariable: VariableSpec
-      yAxisVariable: VariableSpec
-      overlayConfig?: OverlayConfig
-      maxAllowedDataPoints:
-        type: integer
-        required: false
-        format: int64
-  FloatingBoxplot:
-    type: object
-    additionalProperties: false
-    properties:
-      data: BoxplotData[]
-      variables: VariableMapping[]
-  FloatingBoxplotPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      boxplot: FloatingBoxplot
-  FloatingContTablePostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: FloatingContTableSpec
-  FloatingContTableSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      xAxisVariable: VariableSpec
-      yAxisVariable: VariableSpec
-  FloatingContTable:
-    type: object
-    additionalProperties: false
-    properties:
-      data: MosaicData[]
-      variables: VariableMapping[]
-  FloatingContTablePostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      mosaic: FloatingContTable
-      statsTable:
-        type: TwoByTwoStatsTable[]
-        required: false
-  FloatingHistogramPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: FloatingHistogramSpec
-  FloatingHistogramSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      xAxisVariable: VariableSpec
-      barMode:
-        type: string
-        enum:
-          - overlay
-          - stack
-      valueSpec: ValueSpec
-      overlayConfig?: OverlayConfig
-      binSpec: BinSpec
-      viewport:
-        type: NumericViewport
-        required: false
-  FloatingHistogram:
-    type: object
-    additionalProperties: false
-    properties:
-      data: HistogramData[]
-      variables: VariableMapping[]
-  FloatingHistogramPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      histogram: FloatingHistogram
-  FloatingLineplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: FloatingLineplotSpec
-  FloatingLineplotSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      xAxisVariable: VariableSpec
-      yAxisVariable: VariableSpec
-      yAxisNumeratorValues:
-        type: string[]
-        required: false
-      yAxisDenominatorValues:
-        type: string[]
-        required: false
-      overlayConfig?: OverlayConfig
-      binSpec:
-        type: BinSpec
-        required: false
-      valueSpec:
-        type: string
-        enum:
-          - median
-          - mean
-          - geometricMean
-          - proportion
-      errorBars: StringBoolean
-      viewport:
-        type: NumericViewport
-        required: false
-  FloatingLineplot:
-    type: object
-    additionalProperties: false
-    properties:
-      data: LineplotData[]
-      variables: VariableMapping[]
-  FloatingLineplotPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      lineplot: FloatingLineplot
-  FloatingScatterplotPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: FloatingScatterplotSpec
-  FloatingScatterplotSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
       valueSpec:
         type: string
         enum:
@@ -2716,277 +2872,20 @@ types:
           - bestFitLineWithRaw
       xAxisVariable: VariableSpec
       yAxisVariable: VariableSpec
-      overlayConfig?: OverlayConfig
-      maxAllowedDataPoints:
-        type: integer
-        required: false
-        format: int64
-  FloatingScatterplot:
-    type: object
-    additionalProperties: false
-    properties:
-      data: ScatterplotData[]
-      variables: VariableMapping[]
-  FloatingScatterplotPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      scatterplot: FloatingScatterplot
-  StandaloneMapBubblesLegendPostRequest:
-    type: DataPluginRequestBase
-    additionalProperties: false
-    properties:
-      config: StandaloneMapBubblesLegendSpec
-  StandaloneMapBubblesLegendSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      colorLegendConfig: OverlayLegendConfig
-      sizeConfig: SizeLegendConfig
-  OverlayLegendConfig:
-    type: object
-    additionalProperties: false
-    properties:
-      geoAggregateVariable: VariableSpec
-      quantitativeOverlayConfig: QuantitativeOverlayConfig
-  SizeLegendConfig:
-    type: object
-    additionalProperties: false
-    properties:
-      geoAggregateVariable: VariableSpec
-  StandaloneMapBubblesLegendPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      minColorValue: string
-      maxColorValue: string
-      minSizeValue: number
-      maxSizeValue: number
-  StandaloneMapBubblesPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: StandaloneMapBubblesSpec
-  StandaloneMapBubblesSpec:
-    description: Specification for map bubbles.
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId:
-        description: Entity whose cardinality will be reported per marker.
-        type: string
-      geoAggregateVariable:
-        description: Geohash component variable to group markers by. This is usually determined by zoom level of the client application.
-        type: VariableSpec
-      longitudeVariable:
-        description: Variable representing longitude of output entity.
-        type: VariableSpec
-      latitudeVariable:
-        description: Variable representing latitude of output entity.
-        type: VariableSpec
-      overlayConfig?:
-        description: Overlay configuration for quantitative overlay. The quantitative overlay value can be used to render color on the markers.
-        type: QuantitativeOverlayConfig
-      valueSpec: ValueSpec
-      viewport:
-        description: Viewport used to filter markers. Only entities that are contained in the viewport will be grouped into markers.
-        type: GeolocationViewport
-  StandaloneMapBubblesPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      mapElements: ColoredMapElementInfo[]
-  ColoredMapElementInfo:
-    type: BaseMarker
-    additionalProperties: false
-    properties:
-      overlayValue: string
-  StandaloneMapMarkersPostRequest:
-    type: DataPluginRequestBase
-    properties:
-      config: StandaloneMapMarkersSpec
-  StandaloneMapMarkersSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      geoAggregateVariable: VariableSpec
-      longitudeVariable: VariableSpec
-      latitudeVariable: VariableSpec
-      overlayConfig?: OverlayConfig
-      valueSpec: ValueSpec
-      viewport: GeolocationViewport
-  StandaloneMapMarkersPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      mapElements: StandaloneMapElementInfo[]
-  OverlayType:
-    type: string
-    enum:
-      - continuous
-      - categorical
-  OverlayConfig:
-    type: object
-    additionalProperties: false
-    discriminator: overlayType
-    properties:
-      overlayType: OverlayType
-      overlayVariable: VariableSpec
-  ContinousOverlayConfig:
-    type: OverlayConfig
-    additionalProperties: false
-    discriminatorValue: continuous
-    properties:
-      overlayValues:
-        type: LegacyLabeledRange[]
-  CategoricalOverlayConfig:
-    type: OverlayConfig
-    discriminatorValue: categorical
-    additionalProperties: false
-    properties:
-      overlayValues:
-        type: string[]
-  StandaloneMapElementInfo:
-    type: BaseMarker
-    additionalProperties: false
-    properties:
-      overlayValues:
-        type: LegacyLabeledRangeWithCountAndValue[]
-  DataPluginRequestBase:
-    type: object
-    additionalProperties: false
-    properties:
-      studyId: string
-      filters:
-        type: API_Filter[]
-        required: false
-      derivedVariables:
-        type: DerivedVariableSpec[]
-        required: false
-  EmptyDataPluginSpec:
-    type: object
-    additionalProperties: false
-  StringBoolean:
-    type: string
-    enum:
-      - "TRUE"
-      - "FALSE"
-  StrataVariableDetails:
-    type: VariableSpec
-    properties:
-      value: string
-  BinSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      type?:
-        type: string
-        enum:
-          - binWidth
-          - numBins
-      value?: number
-      units?: BinUnits
-      range?: NumberRange | DateRange
-  BinWidthSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      type?:
-        type: string
-        enum:
-          - binWidth
-      value?: number
-      units?: BinUnits
-      range?: NumberRange | DateRange
-  NumberRange:
-    type: object
-    additionalProperties: false
-    properties:
-      min: number
-      max: number
-  DateRange:
-    type: object
-    additionalProperties: false
-    properties:
-      min: string
-      max: string
-  NumericViewport:
-    type: object
-    additionalProperties: false
-    properties:
-      xMin: string
-      xMax: string
-  LongitudeViewport:
-    type: object
-    additionalProperties: false
-    properties:
-      left: number
-      right: number
-  GeolocationViewport:
-    type: object
-    additionalProperties: false
-    properties:
-      latitude: NumericViewport
-      longitude: LongitudeViewport
-  ErrorBar:
-    type: object
-    additionalProperties: false
-    properties:
-      lowerBound: number
-      upperBound: number
-      error: string
-  SimpleSampleSize:
-    type: object
-    additionalProperties: false
-    properties:
-      N: number
-  ProportionSampleSize:
-    type: object
-    additionalProperties: false
-    properties:
-      numeratorN: number
-      denominatorN: number
-  SampleSize: SimpleSampleSize | ProportionSampleSize
-  ShowMissingness:
-    type: string
-    enum:
-      - allVariables
-      - strataVariables
-      - noVariables
-      - "TRUE"
-      - "FALSE"
-  ShowMissingnessNoAxes:
-    type: string
-    enum:
-      - strataVariables
-      - noVariables
-      - "TRUE"
-      - "FALSE"
-  BoxplotWith1ComputeSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      outputEntityId: string
-      showMissingness:
-        type: ShowMissingnessNoAxes
-        required: false
-      points:
-        type: string
-        enum:
-          - outliers
-          - all
-      mean: StringBoolean
-      computeStats: StringBoolean
-      xAxisVariable:
-        type: VariableSpec
-        required: false
       overlayVariable:
         type: VariableSpec
         required: false
       facetVariable:
         type: VariableSpec[]
         maxItems: 2
+        required: false
+      maxAllowedDataPoints:
+        type: integer
+        required: false
+        format: int64
+      correlationMethod: ScatterCorrelationMethod
+      returnPointIds:
+        type: boolean
         required: false
   ScatterplotWith1ComputeSpec:
     type: object
@@ -3013,147 +2912,249 @@ types:
       returnPointIds:
         type: boolean
         required: false
-  Aggregator:
+  SelfCorrelationConfig:
+    type: BaseCorrelationComputeConfig
+    properties:
+      correlationMethod: SelfCorrelationMethod
+      data1: CollectionSpec #someday if we do metadata X metadata, make this CorrelationInputData
+  SelfCorrelationMethod:
     type: string
     enum:
-      - mean
-      - median
-  QuantitativeOverlayConfig:
-    type: object
+      - spearman
+      - pearson
+      - sparcc
+  SelfCorrelationPluginRequest:
+    type: ComputeRequestBase
     properties:
-      overlayVariable: VariableSpec
-      aggregationConfig: QuantitativeAggregationConfig
-  QuantitativeAggregationConfig:
-    type: object
-    additionalProperties: false
-    discriminator: overlayType
+      config: SelfCorrelationConfig
+  SelfCorrelationUnipartitenetworkPostRequest:
+    type: DataPluginRequestBase
     properties:
-      overlayType: OverlayType
-  ContinuousAggregationConfig:
-    type: QuantitativeAggregationConfig
-    additionalProperties: false
-    discriminatorValue: continuous
-    properties:
-      aggregator: Aggregator
-  CategoricalAggregationConfig:
-    type: QuantitativeAggregationConfig
-    discriminatorValue: categorical
-    additionalProperties: false
-    properties:
-      numeratorValues: string[]
-      denominatorValues: string[]
-  CollectionOverlayConfigWithValues:
-    type: CollectionOverlayConfig
-    properties:
-      selectedValues?: string[]
-  DynamicDataSpec: CollectionSpec | VariableSpec
-  LegacyLabeledRange:
-    type: object
-    additionalProperties: false
-    properties:
-      binStart: string
-      binEnd: string
-      binLabel: string
-  LegacyLabeledRangeWithCountAndValue:
-    type: LegacyLabeledRange
-    additionalProperties: false
-    properties:
-      value: number
-      count: number
-  File:
-    type: object
-    additionalProperties: false
-    properties:
-      name: string
-      modifiedDate: string
-      size: string
-  FileContentResponse:
-    type: object
-    properties:
-      //: any
-  DerivedVariableDocumentationRequest:
-    type: object
-    properties:
-      mean: SingleNumericVarReductionConfig
-      sum: SingleNumericVarReductionConfig
-      concatenation: ConcatenationConfig
-      subsetMembership: SubsetMembershipConfig
-      advancedSubset: AdvancedSubsetConfig
-      unitConversion: UnitConversionConfig
-      bodyMassIndex: BodyMassIndexConfig
-      categoricalRecoding: CategoricalRecodingConfig
-      continuousToOrdinal: ContinuousNumericRecodingConfig
-      ecmaScriptExpressionEval: EcmaScriptExpressionEvalConfig
-      relativeObservationMinTimeInterval: RelatedObservationMinTimeIntervalConfig
-  Unit:
-    type: object
-    properties:
-      displayName: string
-      values: string[]
-  UnitType:
-    type: object
-    properties:
-      displayName: string
-      units: Unit[]
-  UnitConversionMetadataResponse:
-    type: object
-    properties:
-      types: UnitType[]
-  SingleNumericVarReductionConfig:
-    type: object
-    properties:
-      inputVariable: VariableSpec
-      imputeZero?: boolean
-  ConcatenationConfig:
-    type: object
-    properties:
-      prefix?: string
-      delimiter?: string
-      suffix?: string
-      inputVariables: VariableSpec[]
-  CategoricalRecodingRule:
-    type: object
-    properties:
-      inputValues: string[]
-      outputValue: string
-  CategoricalRecodingConfig:
-    type: object
-    properties:
-      inputVariable: VariableSpec
-      rules: CategoricalRecodingRule[]
-      unmappedValue?: string
-  ContinuousNumericRule:
-    type: object
-    properties:
-      minInclusive?: number
-      maxExclusive?: number
-      outputValue: string
-  ContinuousNumericRecodingConfig:
-    type: object
-    properties:
-      inputVariable: VariableSpec
-      rules: ContinuousNumericRule[]
-      unmappedValue?: string
-  BodyMassIndexConfig:
-    type: object
-    properties:
-      heightVariable: VariableSpec
-      weightVariable: VariableSpec
-  SubsetMembershipConfig:
-    type: object
-    properties:
-      subsetFilters: API_Filter[]
-  UnitConversionConfig:
-    type: object
-    properties:
-      inputVariable: VariableSpec
-      outputUnits: string
+      computeConfig: SelfCorrelationConfig
+      config: CorrelationNetworkSpec
   SetOperation:
     type: string
     enum:
       - intersect
       - union
       - minus
+  ShowMissingness:
+    type: string
+    enum:
+      - allVariables
+      - strataVariables
+      - noVariables
+      - "TRUE"
+      - "FALSE"
+  ShowMissingnessNoAxes:
+    type: string
+    enum:
+      - strataVariables
+      - noVariables
+      - "TRUE"
+      - "FALSE"
+  SimpleSampleSize:
+    type: object
+    additionalProperties: false
+    properties:
+      N: number
+  SingleAnalysisPatchRequest:
+    type: object
+    additionalProperties: false
+    properties:
+      displayName?: string
+      description?: string
+      notes?: string
+      descriptor?: AnalysisDescriptor
+      isPublic?: boolean
+  SingleAnalysisPublicInfo:
+    type: object
+    additionalProperties: false
+    properties:
+      studyId: string
+  SingleNumericVarReductionConfig:
+    type: object
+    properties:
+      inputVariable: VariableSpec
+      imputeZero?: boolean
+  SizeLegendConfig:
+    type: object
+    additionalProperties: false
+    properties:
+      geoAggregateVariable: VariableSpec
+  SortDirection:
+    type: string
+    enum:
+      - asc
+      - desc
+  SortSpecEntry:
+    type: object
+    additionalProperties: false
+    properties:
+      key: string
+      direction: SortDirection
+  Staff:
+    type: object
+    additionalProperties: false
+    properties:
+      staffId: DatastoreId
+      user: UserDetails
+      isOwner: boolean
+  StaffList:
+    type: object
+    additionalProperties: false
+    properties:
+      data: Staff[]
+      rows:
+        type: integer
+        format: int64
+        minimum: 0
+      offset:
+        type: integer
+        format: int64
+        minimum: 0
+      total:
+        type: integer
+        format: int64
+        minimum: 0
+  StaffPatch:
+    type: object
+    additionalProperties: false
+    properties:
+      op:
+        type: string
+        pattern: ^replace$
+      path:
+        type: string
+        pattern: ^/isOwner$
+      value: boolean
+  StaffPatchRequest:
+    type: array
+    minItems: 1
+    maxItems: 1
+    items: StaffPatch
+  StandaloneCollectionMapMarkerPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: StandaloneCollectionMapMarkerSpec
+  StandaloneCollectionMapMarkerPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      markers: CollectionMapMarkerElement[]
+  StandaloneCollectionMapMarkerSpec:
+    description: Specification for a collection-level map marker visualization.
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId:
+        description: Entity ID associated with collection variable of interest.
+        type: string
+      geoAggregateVariable:
+        description: Geohash component variable to group markers by. This is usually determined by zoom level of the client application.
+        type: VariableSpec
+      longitudeVariable:
+        description: Variable representing longitude of output entity.
+        type: VariableSpec
+      latitudeVariable:
+        description: Variable representing latitude of output entity.
+        type: VariableSpec
+      viewport:
+        description: Viewport used to filter markers. Only entities that are contained in the viewport will be grouped into markers.
+        type: GeolocationViewport
+      collectionOverlay:
+        description: Collection variable to use for markers.
+        type: CollectionOverlayConfig
+      aggregatorConfig:
+        description: Specification for how variable values will be aggregated into quantiative value shown in bar plot marker.
+        type: QuantitativeAggregationConfig
+  StandaloneMapBubblesLegendPostRequest:
+    type: DataPluginRequestBase
+    additionalProperties: false
+    properties:
+      config: StandaloneMapBubblesLegendSpec
+  StandaloneMapBubblesLegendPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      minColorValue: string
+      maxColorValue: string
+      minSizeValue: number
+      maxSizeValue: number
+  StandaloneMapBubblesLegendSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      colorLegendConfig: OverlayLegendConfig
+      sizeConfig: SizeLegendConfig
+  StandaloneMapBubblesPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: StandaloneMapBubblesSpec
+  StandaloneMapBubblesPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      mapElements: ColoredMapElementInfo[]
+  StandaloneMapBubblesSpec:
+    description: Specification for map bubbles.
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId:
+        description: Entity whose cardinality will be reported per marker.
+        type: string
+      geoAggregateVariable:
+        description: Geohash component variable to group markers by. This is usually determined by zoom level of the client application.
+        type: VariableSpec
+      longitudeVariable:
+        description: Variable representing longitude of output entity.
+        type: VariableSpec
+      latitudeVariable:
+        description: Variable representing latitude of output entity.
+        type: VariableSpec
+      overlayConfig?:
+        description: Overlay configuration for quantitative overlay. The quantitative overlay value can be used to render color on the markers.
+        type: QuantitativeOverlayConfig
+      valueSpec: ValueSpec
+      viewport:
+        description: Viewport used to filter markers. Only entities that are contained in the viewport will be grouped into markers.
+        type: GeolocationViewport
+  StandaloneMapElementInfo:
+    type: BaseMarker
+    additionalProperties: false
+    properties:
+      overlayValues:
+        type: LegacyLabeledRangeWithCountAndValue[]
+  StandaloneMapMarkersPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: StandaloneMapMarkersSpec
+  StandaloneMapMarkersPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      mapElements: StandaloneMapElementInfo[]
+  StandaloneMapMarkersSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      geoAggregateVariable: VariableSpec
+      longitudeVariable: VariableSpec
+      latitudeVariable: VariableSpec
+      overlayConfig?: OverlayConfig
+      valueSpec: ValueSpec
+      viewport: GeolocationViewport
+  Statistic:
+    type: object
+    additionalProperties: false
+    properties:
+      value: number
+      confidenceInterval?: string
+      confidenceLevel?: number
+      pvalue: string
   Step:
     type: object
     properties:
@@ -3165,174 +3166,129 @@ types:
       rightStepKey?: string
       rightVariable?: VariableSpec
       rightVariableTrueValues?: string[]
-  AdvancedSubsetConfig:
-    type: object
+  StrataVariableDetails:
+    type: VariableSpec
     properties:
-      rootStepKey: string
-      steps: Step[]
-  VariableReference:
-    type: object
-    properties:
-      name: string
-      variable: VariableSpec
-  EcmaScriptExpressionEvalConfig:
-    type: object
-    properties:
-      ecmaScriptExpression: string
-      nullResultOnAnyMissingInput: boolean
-      inputVariables: VariableReference[]
-      expectedType: API_VariableType
-      expectedShape: API_VariableDataShape
-  RelatedObservationMinTimeIntervalConfig:
-    type: object
-    properties:
-      relatedObservationsSubset: API_Filter[]
-      anchorVariable: VariableSpec
-      anchorVariableTrueValues: string[]
-      anchorTimestampVariable: VariableSpec
-      targetVariable: VariableSpec
-      targetVariableTrueValues: string[]
-      targetTimestampVariable: VariableSpec
-      minimumTimeIntervalDays: integer
-  AnalysisBase:
+      value: string
+  StringBoolean:
+    type: string
+    enum:
+      - "TRUE"
+      - "FALSE"
+  StudiesGetResponse:
     type: object
     additionalProperties: false
     properties:
-      displayName: string
-      description: string
-      studyId: string
-      studyVersion: string
-      apiVersion: string
-      isPublic: boolean
-  OnImportProvenanceProps:
-    type: object
-    additionalProperties: false
-    properties:
-      ownerId:
-        type: integer
-        format: int64
-      ownerName: string
-      ownerOrganization: string
-      analysisId: string
-      analysisName: string
-      creationTime: string
-      modificationTime: string
-      isPublic: boolean
-  CurrentProvenanceProps:
-    type: object
-    additionalProperties: false
-    properties:
-      isDeleted: boolean
-      modificationTime?: string
-      isPublic?: boolean
-  AnalysisProvenance:
-    type: object
-    additionalProperties: false
-    properties:
-      onImport: OnImportProvenanceProps
-      current: CurrentProvenanceProps
-  AnalysisSummary:
-    type: AnalysisBase
-    additionalProperties: false
-    properties:
-      analysisId: string
-      creationTime: string
-      modificationTime: string
-      numFilters: integer
-      numComputations: integer
-      numVisualizations: integer
-      provenance?: AnalysisProvenance
-  AnalysisSummaryWithUser:
-    type: AnalysisSummary
-    additionalProperties: false
-    properties:
-      userId: number
-      userName: string
-      userOrganization: string
-  AnalysisListPostRequest:
-    type: AnalysisBase
-    additionalProperties: false
-    properties:
-      notes?: string
-      descriptor: AnalysisDescriptor
-  AnalysisListPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      analysisId: string
-  AnalysisListPatchRequest:
-    type: object
-    additionalProperties: false
-    properties:
-      analysisIdsToDelete?: string[]
-      inheritOwnershipFrom?:
-        type: integer
-        format: int64
-  AnalysisDetail:
-    type: AnalysisSummary
-    additionalProperties: false
-    properties:
-      notes?: string
-      descriptor: AnalysisDescriptor
-  SingleAnalysisPatchRequest:
-    type: object
-    additionalProperties: false
-    properties:
-      displayName?: string
-      description?: string
-      notes?: string
-      descriptor?: AnalysisDescriptor
-      isPublic?: boolean
-  DataTableConfig:
-    type: object
-    additionalProperties: false
-    properties:
-      variables: VariableSpec[]
-      sorting: SortSpecEntry[]
-  DataTableConfigSet:
-    type: object
-    properties:
-      //: DataTableConfig
-  AnalysisDescriptor:
-    type: object
-    additionalProperties: false
-    properties:
-      subset:
-        type: object
-        properties:
-          descriptor: object[]
-          uiSettings?: object
-      computations: Computation[]
-      starredVariables: VariableSpec[]
-      dataTableConfig: DataTableConfigSet
-      derivedVariables: string[]
-  Computation:
-    type: object
-    additionalProperties: false
-    properties:
-      computationId: string
-      displayName: string
-      descriptor: object
-      visualizations: Visualization[]
-  Visualization:
-    type: object
-    additionalProperties: false
-    properties:
-      visualizationId: string
-      displayName: string
-      descriptor: object
-  SingleAnalysisPublicInfo:
+      studies: API_StudyOverview[]
+  StudyCount:
     type: object
     additionalProperties: false
     properties:
       studyId: string
-  UserAnalysisMetricsResponse:
+      count: integer
+  StudyIdGetResponse:
     type: object
     additionalProperties: false
     properties:
-      startDate: date-only
-      endDate: date-only
-      createdOrModifiedCounts: UserAnalysisCounts
+      study: API_StudyDetail
+  StudyPermissionInfo:
+    type: object
+    additionalProperties: false
+    properties:
+      studyId: string
+      datasetId: string
+      isUserStudy: boolean
+      actionAuthorization: ActionList
+  StudySourceType:
+    type: string
+    enum:
+      - curated
+      - user_submitted
+  SubsetMembershipConfig:
+    type: object
+    properties:
+      subsetFilters: API_Filter[]
+  TablePostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: TableSpec
+  TablePostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      columns: VariableSpec[]
+      rows: string[][]
+  TableSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      outputEntityId: string
+      outputVariable: VariableSpec[]
+      pagingConfig: API_PagingConfig
+  TabularHeaderFormat:
+    type: string
+    enum:
+      - standard
+      - display
+  TestCollectionsPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: CollectionSpec
+  TwoByTwoPostRequest:
+    type: DataPluginRequestBase
+    properties:
+      config: TwoByTwoSpec
+  TwoByTwoPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      mosaic: Mosaic
+      sampleSizeTable: SampleSizeTable[]
+      statsTable:
+        type: TwoByTwoStatsTable[]
+        required: false
+      completeCasesTable: VariableCompleteCases[]
+  TwoByTwoSpec:
+    type: MosaicSpec
+    properties:
+      xAxisReferenceValue: string
+      yAxisReferenceValue: string
+  TwoByTwoStatsTable:
+    type: object
+    additionalProperties: false
+    properties:
+      facetVariableDetails:
+        type: StrataVariableDetails[]
+        maxItems: 2
+        required: false
+      chisq: Statistic
+      fisher: Statistic
+      prevalence?: Statistic
+      oddsratio?: Statistic
+      relativerisk?: Statistic
+      sensitivity?: Statistic
+      specificity?: Statistic
+      posPredictiveValue?: Statistic
+      negPredictiveValue?: Statistic
+  Unit:
+    type: object
+    properties:
+      displayName: string
+      values: string[]
+  UnitConversionConfig:
+    type: object
+    properties:
+      inputVariable: VariableSpec
+      outputUnits: string
+  UnitConversionMetadataResponse:
+    type: object
+    properties:
+      types: UnitType[]
+  UnitType:
+    type: object
+    properties:
+      displayName: string
+      units: Unit[]
   UserAnalysisCounts:
     type: object
     additionalProperties: false
@@ -3355,66 +3311,117 @@ types:
       guestUsersFiltersCounts: UsersObjectsCount[]
       registeredUsersVisualizationsCounts: UsersObjectsCount[]
       guestUsersVisualizationsCounts: UsersObjectsCount[]
-  StudyCount:
+  UserAnalysisMetricsResponse:
     type: object
     additionalProperties: false
     properties:
-      studyId: string
-      count: integer
+      startDate: date-only
+      endDate: date-only
+      createdOrModifiedCounts: UserAnalysisCounts
+  UserDetails:
+    type: object
+    additionalProperties: false
+    properties:
+      userId:
+        type: integer
+        format: int64
+        minimum: 1
+      firstName: string
+      lastName: string
+      organization: string
+      email: string
   UsersObjectsCount:
     type: object
     additionalProperties: false
     properties:
       objectsCount: integer
       usersCount: integer
-  MetricsReportResponse:
+  ValueSpec:
+    type: string
+    enum:
+      - count
+      - proportion
+  VariableClass:
+    type: string
+    enum:
+      - native
+      - derived
+      - computed
+  VariableCompleteCases:
     type: object
     additionalProperties: false
     properties:
-      count: integer
-  DerivedVariablePostRequest:
+      variableDetails: VariableSpec
+      completeCases: number
+  VariableDistributionPostRequest:
     type: object
     additionalProperties: false
     properties:
-      datasetId: string
+      filters: API_Filter[]
+      binSpec?: BinSpecWithRange
+      valueSpec: ValueSpec
+  VariableDistributionPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      histogram: HistogramBin[]
+      statistics: HistogramStats
+  VariableMapping:
+    type: object
+    additionalProperties: false
+    properties:
+      variableClass: VariableClass
+      variableSpec: VariableSpec
+      plotReference: PlotReferenceValue
+      dataType: API_VariableType
+      dataShape: API_VariableDataShape
+      displayName?: string
+      displayRangeMin?: any
+      displayRangeMax?: any
+      vocabulary?: string[]
+      imputeZero: boolean
+      hasStudyDependentVocabulary?: boolean
+      isCollection: boolean
+      members?: VariableSpec[]
+  VariableReference:
+    type: object
+    properties:
+      name: string
+      variable: VariableSpec
+  VariableSpec:
+    type: object
+    additionalProperties: false
+    properties:
       entityId: string
-      displayName:
-        type: string
-        minLength: 1
-        maxLength: 256
-      functionName: string
-      config: object
-      description?:
-        type: string
-        maxLength: 4000
-  DerivedVariablePostResponse:
-    type: VariableSpec
-    additionalProperties: false
-  DerivedVariableGetResponse:
-    type: DerivedVariableSpec
-    additionalProperties: false
-    properties:
-      datasetId: string
-      description?:
-        type: string
-        minLength: 0
-        maxLength: 4000
-      provenance?: DerivedVariableProvenance
-  DerivedVariablePatchRequest:
+      variableId: string
+  Visualization:
     type: object
     additionalProperties: false
     properties:
-      displayName?:
-        type: string
-        minLength: 1
-        maxLength: 256
-      description?:
-        type: string
-        maxLength: 4000
-  DerivedVariableProvenance:
+      visualizationId: string
+      displayName: string
+      descriptor: object
+  VisualizationOverview:
     type: object
     additionalProperties: false
     properties:
-      copyDate: datetime-only
-      copiedFrom: string
+      name: string
+      displayName: string
+      description: string
+      projects: string[]
+      maxPanels: number
+      dataElementConstraints:
+        type: DataElementConstraintPattern[]
+        required: false
+      dataElementDependencyOrder:
+        type: string[][]
+        required: false
+  VocabByRootEntityPostRequest:
+    type: object
+    additionalProperties: false
+    properties:
+      filters: API_Filter[]
+  VocabByRootEntityPostResponse:
+    type: EntityTabularPostResponse
+    additionalProperties: false
 

--- a/schema/url/data/correlation/plugin-correlation-bipartitenetwork.raml
+++ b/schema/url/data/correlation/plugin-correlation-bipartitenetwork.raml
@@ -15,6 +15,10 @@ types:
         type: string
         enum: ['none','force','circle','nicely']
       degree: boolean
+      correlationDirection: 
+        type: string
+        enum: ['both','positive','negative']
+        required: false
 
   CorrelationBipartiteNetworkPostResponse:
     additionalProperties: false

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/correlation/AbstractCorrelationBipartiteNetwork.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/correlation/AbstractCorrelationBipartiteNetwork.java
@@ -74,6 +74,17 @@ public abstract class AbstractCorrelationBipartiteNetwork<T extends DataPluginRe
         if (Float.parseFloat(correlationRow.getPValue()) > pValueThreshold.floatValue()) return;
       }
 
+      // Skip rows that do not match the correlation direction, if specified
+      // Do nothing if the direction is "both".
+      String correlationDirection = getPluginSpec().getCorrelationDirection() != null ? getPluginSpec().getCorrelationDirection().getValue() : "both";
+      if (correlationDirection != null && !correlationDirection.equals("both")) {
+        if (correlationDirection.equals("positive") && Float.parseFloat(correlationRow.getCorrelationCoef()) < 0) {
+          return;
+        } else if (correlationDirection.equals("negative") && Float.parseFloat(correlationRow.getCorrelationCoef()) > 0) {
+          return;
+        }
+      }
+
       // First add the node ids (data1 and data2 from this row) to our growing list of node ids
       // We'll worry about duplicates later.
       nodeIDs.add(correlationRow.getData1());

--- a/src/main/java/org/veupathdb/service/eda/data/plugin/selfcorrelation/SelfCorrelationUnipartitenetworkPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/data/plugin/selfcorrelation/SelfCorrelationUnipartitenetworkPlugin.java
@@ -63,6 +63,7 @@ public class SelfCorrelationUnipartitenetworkPlugin extends AbstractPlugin<SelfC
     writeComputeStatsResponseToOutput(statsBytes);
     ByteArrayInputStream statsIn = new ByteArrayInputStream(statsBytes.toByteArray());
     dataStreams.put("statsFile.json", statsIn);
+    String correlationDirection = spec.getCorrelationDirection() != null ? spec.getCorrelationDirection().getValue() : "both";
 
     // some default filtering thresholds
     Number correlationCoefThreshold = getPluginSpec().getCorrelationCoefThreshold() != null ? getPluginSpec().getCorrelationCoefThreshold() : 0.2;
@@ -74,6 +75,11 @@ public class SelfCorrelationUnipartitenetworkPlugin extends AbstractPlugin<SelfC
       connection.voidEval("names(edgeList) <- c('source', 'target', 'correlationCoef', 'pValue')");
       connection.voidEval("edgeList$pValue <- as.numeric(edgeList$pValue)");
       connection.voidEval("edgeList$correlationCoef <- as.numeric(edgeList$correlationCoef)");
+      if (correlationDirection.equals("positive")) {
+        connection.voidEval("edgeList <- edgeList[edgeList$correlationCoef >= 0, ]");
+      } else if (correlationDirection.equals("negative")) {
+        connection.voidEval("edgeList <- edgeList[edgeList$correlationCoef <= 0, ]");
+      }
       connection.voidEval("net <- plot.data::CorrelationNetwork(edgeList" +
           ", correlationCoefThreshold = as.numeric(" + correlationCoefThreshold + ")" +
           ", pValueThreshold = as.numeric(" + pValueThreshold + ")" +


### PR DESCRIPTION
Resolves #91 

Works with monorepo PR https://github.com/VEuPathDB/web-monorepo/pull/1492

Adds an optional `correlationDirection` option for correlation networks. This should return only links that reprepsent positive, negative, or either correlation directions based on the specifications.

Changed "linkType" to "correlationDirection" since the latter is more specific.