### PR TITLE
Bug: duplicate column crash in collection × collection correlation (WGCNA eigengenes)

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/correlation/CorrelationPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/correlation/CorrelationPlugin.java
@@ -291,7 +291,7 @@ public class CorrelationPlugin extends AbstractPlugin<CorrelationPluginRequest, 
         // if were not on the same entity, we can remove the collection entity id from the id columns
         if (!isSameEntity) {
           entityIdColumns.remove(revisedComputeEntityIdVarSpec);
-          entity2IdColumns.remove(entity2IdVarSpec);
+          entity2IdColumns.remove(revisedComputeEntityIdVarSpec);
         }
 
         // read both sets of collection data into R


### PR DESCRIPTION
When both `data1` and `data2` are eigengene collections on different entities (siblings under a shared parent), the `fread` call for `input2Data` fails because the shared parent entity's ID column is selected twice.

Occurs with this payload:

```json
{
  "config": {
    "correlationMethod": "spearman",
    "data1": {
      "collectionSpec": {
        "collectionId": "EUPATH_0005051",
        "entityId": "hsapREF_WGCNA_DATA"
      },
      "dataType": "collection"
    },
    "data2": {
      "collectionSpec": {
        "collectionId": "EUPATH_0005051",
        "entityId": "pfal3D7_WGCNA_DATA"
      },
      "dataType": "collection"
    },
    "prefilterThresholds": {
      "proportionNonZero": 0.08,
      "standardDeviation": 0,
      "variance": 0
    }
  },
  "derivedVariables": [],
  "filters": [],
  "studyId": "STUDY_fd06cb37d3"
}
```

Rserve error:

```
[1] "starting correlation computation"
Error in data.table::fread("input2Data", select = c(ENT_8151325d.sample_stable_id = "double",  : 
  Column number 2 ('ENT_8151325d.sample_stable_id') has been selected twice by select=
In addition: Warning messages:
1: In data.table::fread("inputData", select = c(hsapREF_WGCNA_DATA.hspREFegng_stable_id = "double",  :
  Attempt to override column 1 <<hsapREF_WGCNA_DATA.hspREFegng_stable_id>> of inherent type 'string' down to 'float64' ignored.
2: In data.table::fread("inputData", select = c(hsapREF_WGCNA_DATA.hspREFegng_stable_id = "double",  :
  Attempt to override column 2 <<ENT_8151325d.sample_stable_id>> of inherent type 'string' down to 'float64' ignored.
```

Does not affect eigengenes × continuous metadata, only eigengenes × eigengenes (cross-entity).
