### PR TITLE
Handle missing-sample data in microbiome alpha diversity, beta diversity, and ranked abundance computes

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/common/plugin/util/PluginUtil.java
+++ b/src/main/java/org/veupathdb/service/eda/common/plugin/util/PluginUtil.java
@@ -230,6 +230,7 @@ public class PluginUtil {
 
     return fileName +
       " <- data.table::fread(" + singleQuote(fileName) +
+      ", sep='\\t'" +
       ", select=c(" + namedTypes + ")" +
       ", na.strings=c(''))";
   }

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/alphadiv/AlphaDivPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/alphadiv/AlphaDivPlugin.java
@@ -23,6 +23,7 @@ import java.util.List;
 public class AlphaDivPlugin extends AbstractPlugin<AlphaDivPluginRequest, AlphaDivComputeConfig> {
 
   private static final String INPUT_DATA = "alpha_div_input";
+  private static final String SAMPLE_DATA = "sample_entity_input";
 
   public AlphaDivPlugin(@NotNull PluginContext<AlphaDivPluginRequest, AlphaDivComputeConfig> context) {
     super(context);
@@ -31,8 +32,12 @@ public class AlphaDivPlugin extends AbstractPlugin<AlphaDivPluginRequest, AlphaD
   @NotNull
   @Override
   public List<StreamSpec> getStreamSpecs() {
-    return List.of(new StreamSpec(INPUT_DATA, getConfig().getCollectionVariable().getEntityId())
-      .addVars(getUtil().getCollectionMembers(getConfig().getCollectionVariable())));
+    String entityId = getConfig().getCollectionVariable().getEntityId();
+    return List.of(
+      new StreamSpec(INPUT_DATA, entityId)
+        .addVars(getUtil().getCollectionMembers(getConfig().getCollectionVariable())),
+      new StreamSpec(SAMPLE_DATA, entityId)  // just ID columns, no extra vars
+    );
   }
 
   @Override
@@ -47,9 +52,13 @@ public class AlphaDivPlugin extends AbstractPlugin<AlphaDivPluginRequest, AlphaD
     EntityDef entity = meta.getEntity(entityId).orElseThrow();
     VariableDef computeEntityIdVarSpec = util.getEntityIdVarSpec(entityId);
     String computeEntityIdColName = util.toColNameOrEmpty(computeEntityIdVarSpec);
+    String shortIdColName = computeEntityIdColName.contains(".")
+      ? computeEntityIdColName.substring(computeEntityIdColName.lastIndexOf('.') + 1)
+      : computeEntityIdColName;
     String method = computeConfig.getAlphaDivMethod().getValue();
     HashMap<String, InputStream> dataStream = new HashMap<>();
     dataStream.put(INPUT_DATA, getWorkspace().openStream(INPUT_DATA));
+    dataStream.put(SAMPLE_DATA, getWorkspace().openStream(SAMPLE_DATA));
     List<VariableDef> idColumns = new ArrayList<>();
     for (EntityDef ancestor : meta.getAncestors(entity)) {
       idColumns.add(ancestor.getIdColumnDef());
@@ -62,6 +71,12 @@ public class AlphaDivPlugin extends AbstractPlugin<AlphaDivPluginRequest, AlphaD
       computeInputVars.addAll(util.getCollectionMembers(computeConfig.getCollectionVariable()));
       computeInputVars.addAll(idColumns);
       connection.voidEval(util.getVoidEvalFreadCommand(INPUT_DATA, computeInputVars));
+      List<VariableSpec> sampleIdVars = new ArrayList<>();
+      sampleIdVars.add(computeEntityIdVarSpec);
+      sampleIdVars.addAll(idColumns);
+      connection.voidEval(util.getVoidEvalFreadCommand(SAMPLE_DATA, sampleIdVars));
+      // Strip entity prefix from all ID column names to match the short names used by the compute output
+      connection.voidEval("data.table::setnames(" + SAMPLE_DATA + ", names(" + SAMPLE_DATA + "), sub('^[^.]+\\\\.', '', names(" + SAMPLE_DATA + ")))");
       List<String> dotNotatedIdColumns = idColumns.stream().map(VariableDef::toDotNotation).toList();
       StringBuilder dotNotatedIdColumnsString = new StringBuilder("c(");
       boolean first = true;
@@ -82,6 +97,15 @@ public class AlphaDivPlugin extends AbstractPlugin<AlphaDivPluginRequest, AlphaD
 
       connection.voidEval("alphaDivDT <- alphaDiv(abundDT, " +
         PluginUtil.singleQuote(method) + ", TRUE)");
+
+      // Left-join results onto full sample list so samples with no abundance data get NA values.
+      connection.voidEval("alphaDivData <- alphaDivDT@data");
+      connection.voidEval("alphaDivData <- merge(" + SAMPLE_DATA + ", alphaDivData, by=names(" + SAMPLE_DATA + "), all.x=TRUE, sort=FALSE)");
+      connection.voidEval("alphaDivData <- alphaDivData[match(" + SAMPLE_DATA + "[[" +
+        PluginUtil.singleQuote(shortIdColName) + "]], alphaDivData[[" +
+        PluginUtil.singleQuote(shortIdColName) + "]])]");
+      connection.voidEval("alphaDivDT@data <- alphaDivData");
+
       String dataCmd = "writeData(alphaDivDT, NULL, TRUE)";
       String metaCmd = "writeMeta(alphaDivDT, NULL, TRUE)";
 

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/betadiv/BetaDivPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/betadiv/BetaDivPlugin.java
@@ -25,6 +25,7 @@ import static org.veupathdb.service.eda.common.plugin.util.PluginUtil.singleQuot
 public class BetaDivPlugin extends AbstractPlugin<BetaDivPluginRequest, BetaDivComputeConfig> {
 
   private static final String INPUT_DATA = "beta_div_input";
+  private static final String SAMPLE_DATA = "sample_entity_input";
 
   public BetaDivPlugin(@NotNull PluginContext<BetaDivPluginRequest, BetaDivComputeConfig> context) {
     super(context);
@@ -33,9 +34,12 @@ public class BetaDivPlugin extends AbstractPlugin<BetaDivPluginRequest, BetaDivC
   @NotNull
   @Override
   public List<StreamSpec> getStreamSpecs() {
-    return List.of(new StreamSpec(INPUT_DATA, getConfig().getCollectionVariable().getEntityId())
-      .addVars(getUtil().getCollectionMembers(getConfig().getCollectionVariable())
-    ));
+    String entityId = getConfig().getCollectionVariable().getEntityId();
+    return List.of(
+      new StreamSpec(INPUT_DATA, entityId)
+        .addVars(getUtil().getCollectionMembers(getConfig().getCollectionVariable())),
+      new StreamSpec(SAMPLE_DATA, entityId)  // just ID columns, no extra vars
+    );
   }
 
   @Override
@@ -50,9 +54,13 @@ public class BetaDivPlugin extends AbstractPlugin<BetaDivPluginRequest, BetaDivC
     EntityDef entity = meta.getEntity(entityId).orElseThrow();
     VariableDef computeEntityIdVarSpec = util.getEntityIdVarSpec(entityId);
     String computeEntityIdColName = util.toColNameOrEmpty(computeEntityIdVarSpec);
+    String shortIdColName = computeEntityIdColName.contains(".")
+      ? computeEntityIdColName.substring(computeEntityIdColName.lastIndexOf('.') + 1)
+      : computeEntityIdColName;
     String dissimilarityMethod = computeConfig.getBetaDivDissimilarityMethod().getValue();
     HashMap<String, InputStream> dataStream = new HashMap<>();
     dataStream.put(INPUT_DATA, getWorkspace().openStream(INPUT_DATA));
+    dataStream.put(SAMPLE_DATA, getWorkspace().openStream(SAMPLE_DATA));
     List<VariableDef> idColumns = new ArrayList<>();
     for (EntityDef ancestor : meta.getAncestors(entity)) {
       idColumns.add(ancestor.getIdColumnDef());
@@ -66,6 +74,12 @@ public class BetaDivPlugin extends AbstractPlugin<BetaDivPluginRequest, BetaDivC
       computeInputVars.addAll(idColumns);
       connection.voidEval(util.getVoidEvalFreadCommand(INPUT_DATA, computeInputVars));
       computeInputVars.clear();
+      List<VariableSpec> sampleIdVars = new ArrayList<>();
+      sampleIdVars.add(computeEntityIdVarSpec);
+      sampleIdVars.addAll(idColumns);
+      connection.voidEval(util.getVoidEvalFreadCommand(SAMPLE_DATA, sampleIdVars));
+      // Strip entity prefix from all ID column names to match the short names used by the compute output
+      connection.voidEval("data.table::setnames(" + SAMPLE_DATA + ", names(" + SAMPLE_DATA + "), sub('^[^.]+\\\\.', '', names(" + SAMPLE_DATA + ")))");
       List<String> dotNotatedIdColumns = idColumns.stream().map(VariableDef::toDotNotation).toList();
       StringBuilder dotNotatedIdColumnsString = new StringBuilder("c(");
       boolean first = true;
@@ -85,6 +99,14 @@ public class BetaDivPlugin extends AbstractPlugin<BetaDivPluginRequest, BetaDivC
                                                                           ",imputeZero=TRUE)");
       connection.voidEval("betaDivDT <- betaDiv(abundDT, " +
                                                 singleQuote(dissimilarityMethod) + ")");
+
+      // Left-join results onto full sample list so samples with no abundance data get NA values.
+      connection.voidEval("betaDivData <- betaDivDT@data");
+      connection.voidEval("betaDivData <- merge(" + SAMPLE_DATA + ", betaDivData, by=names(" + SAMPLE_DATA + "), all.x=TRUE, sort=FALSE)");
+      connection.voidEval("betaDivData <- betaDivData[match(" + SAMPLE_DATA + "[[" +
+        singleQuote(shortIdColName) + "]], betaDivData[[" +
+        singleQuote(shortIdColName) + "]])]");
+      connection.voidEval("betaDivDT@data <- betaDivData");
 
       String dataCmd = "writeData(betaDivDT, NULL, TRUE)";
       String metaCmd = "writeMeta(betaDivDT, NULL, TRUE)";

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/rankedabundance/RankedAbundancePlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/rankedabundance/RankedAbundancePlugin.java
@@ -22,6 +22,7 @@ import java.util.List;
 public class RankedAbundancePlugin extends AbstractPlugin<RankedAbundancePluginRequest, RankedAbundanceComputeConfig> {
 
   private static final String INPUT_DATA = "ranked_abundance_input";
+  private static final String SAMPLE_DATA = "sample_entity_input";
 
   public RankedAbundancePlugin(@NotNull PluginContext<RankedAbundancePluginRequest, RankedAbundanceComputeConfig> context) {
     super(context);
@@ -30,9 +31,12 @@ public class RankedAbundancePlugin extends AbstractPlugin<RankedAbundancePluginR
   @NotNull
   @Override
   public List<StreamSpec> getStreamSpecs() {
-    return List.of(new StreamSpec(INPUT_DATA, getConfig().getCollectionVariable().getEntityId())
-        .addVars(getUtil().getCollectionMembers(getConfig().getCollectionVariable())
-      ));
+    String entityId = getConfig().getCollectionVariable().getEntityId();
+    return List.of(
+      new StreamSpec(INPUT_DATA, entityId)
+        .addVars(getUtil().getCollectionMembers(getConfig().getCollectionVariable())),
+      new StreamSpec(SAMPLE_DATA, entityId)  // just ID columns, no extra vars
+    );
   }
 
   @Override
@@ -47,9 +51,13 @@ public class RankedAbundancePlugin extends AbstractPlugin<RankedAbundancePluginR
     EntityDef entity = meta.getEntity(entityId).orElseThrow();
     VariableDef computeEntityIdVarSpec = util.getEntityIdVarSpec(entityId);
     String computeEntityIdColName = util.toColNameOrEmpty(computeEntityIdVarSpec);
+    String shortIdColName = computeEntityIdColName.contains(".")
+      ? computeEntityIdColName.substring(computeEntityIdColName.lastIndexOf('.') + 1)
+      : computeEntityIdColName;
     String method = computeConfig.getRankingMethod().getValue();
     HashMap<String, InputStream> dataStream = new HashMap<>();
     dataStream.put(INPUT_DATA, getWorkspace().openStream(INPUT_DATA));
+    dataStream.put(SAMPLE_DATA, getWorkspace().openStream(SAMPLE_DATA));
     List<VariableDef> idColumns = new ArrayList<>();
     for (EntityDef ancestor : meta.getAncestors(entity)) {
       idColumns.add(ancestor.getIdColumnDef());
@@ -64,6 +72,12 @@ public class RankedAbundancePlugin extends AbstractPlugin<RankedAbundancePluginR
         addAll(idColumns);
       }};
       connection.voidEval(util.getVoidEvalFreadCommand(INPUT_DATA, computeInputVars));
+      List<VariableSpec> sampleIdVars = new ArrayList<>();
+      sampleIdVars.add(computeEntityIdVarSpec);
+      sampleIdVars.addAll(idColumns);
+      connection.voidEval(util.getVoidEvalFreadCommand(SAMPLE_DATA, sampleIdVars));
+      // Strip entity prefix from all ID column names to match the short names used by the compute output
+      connection.voidEval("data.table::setnames(" + SAMPLE_DATA + ", names(" + SAMPLE_DATA + "), sub('^[^.]+\\\\.', '', names(" + SAMPLE_DATA + ")))");
       // TODO make a helper for this i think
       List<String> dotNotatedIdColumns = idColumns.stream().map(VariableDef::toDotNotation).toList();
       StringBuilder dotNotatedIdColumnsString = new StringBuilder("c(");
@@ -84,6 +98,15 @@ public class RankedAbundancePlugin extends AbstractPlugin<RankedAbundancePluginR
                                                                           ",imputeZero=TRUE)");
       connection.voidEval("abundanceDT <- rankedAbundance(abundDT, " +
                                                           PluginUtil.singleQuote(method) + ")");
+
+      // Left-join results onto full sample list so samples with no abundance data get NA values.
+      connection.voidEval("abundanceData <- abundanceDT@data");
+      connection.voidEval("abundanceData <- merge(" + SAMPLE_DATA + ", abundanceData, by=names(" + SAMPLE_DATA + "), all.x=TRUE, sort=FALSE)");
+      connection.voidEval("abundanceData <- abundanceData[match(" + SAMPLE_DATA + "[[" +
+        PluginUtil.singleQuote(shortIdColName) + "]], abundanceData[[" +
+        PluginUtil.singleQuote(shortIdColName) + "]])]");
+      connection.voidEval("abundanceDT@data <- abundanceData");
+
       String dataCmd = "writeData(abundanceDT, NULL, TRUE)";
       String metaCmd = "writeMeta(abundanceDT, NULL, TRUE)";
 


### PR DESCRIPTION
Fixes #126
Fixes #78 

The merge service expects compute output to contain one row per sample in the subset. When a sample has all-missing abundance data it was silently dropped from the microbiome compute outputs, causing the merge service to fail with a row-order mismatch error.

### Changes

**`AlphaDivPlugin`, `BetaDivPlugin`, `RankedAbundancePlugin`**

Applies the same fix introduced for PCA in #140. Each plugin now requests a second data stream (`SAMPLE_DATA`) for the collection entity containing only ID columns, giving a complete ordered list of all samples. After the R computation, the result is left-joined onto this complete list so that samples with no usable abundance data receive NA values rather than being absent from the output.

The R compute functions (alphaDiv, betaDiv, rankedAbundance) output ID columns with entity prefixes stripped via stripEntityIdFromColumnHeader, so the SAMPLE_DATA column names are normalised to match using setnames(..., sub('^[^.]+\\.', '', ...)) before the merge.                                                                                                                         

**`PluginUtil.getVoidEvalFreadCommand`**

Added `sep='\t'` to all generated `data.table::fread` calls. Without this, fread's auto-detection chose space as the separator when reading narrow streams (e.g. a single ID column), silently splitting values like `Sample1 (Source)` into two tokens and reading the wrong one. All streams in this service are tab-delimited, so explicit `sep='\t'` is correct universally.

### Testing

Manually tested alpha diversity, beta diversity, and ranked abundance computes against studies where a subset of samples have all-missing abundance data, including multi-entity datasets. All computes now return one row per sample with NA values for missing samples, and the merge service no longer reports row-order mismatches.
